### PR TITLE
Unittest groupfile alt

### DIFF
--- a/src/test/java/com/bitheads/braincloud/services/AuthenticationServiceTest.java
+++ b/src/test/java/com/bitheads/braincloud/services/AuthenticationServiceTest.java
@@ -11,19 +11,16 @@ import com.bitheads.braincloud.client.AuthenticationType;
 import com.bitheads.braincloud.client.ReasonCodes;
 import com.bitheads.braincloud.client.StatusCodes;
 
-
 /**
  * Created by prestonjennings on 15-08-31.
  */
-public class AuthenticationServiceTest extends TestFixtureNoAuth
-{
+public class AuthenticationServiceTest extends TestFixtureNoAuth {
 
     long mostRecentPacket = -1000000;
     long secondMostRecentPacket = -1000000;
 
     @Test
-    public void testAuthManualRedirect() throws Exception
-    {
+    public void testAuthManualRedirect() throws Exception {
         _client.initialize(m_serverUrl, m_redirectAppId, m_secret, m_appVersion);
 
         TestResult tr = new TestResult(_wrapper);
@@ -34,8 +31,7 @@ public class AuthenticationServiceTest extends TestFixtureNoAuth
     }
 
     @Test
-    public void testAuthenticateAnonymous() throws Exception
-    {
+    public void testAuthenticateAnonymous() throws Exception {
         TestResult tr = new TestResult(_wrapper);
         String anonId = _client.getAuthenticationService().generateAnonymousId();
         _client.getAuthenticationService().authenticateAnonymous(anonId, true, tr);
@@ -44,48 +40,46 @@ public class AuthenticationServiceTest extends TestFixtureNoAuth
     }
 
     @Test
-    public void testAuthenticateUniversalInstance() throws Exception
-    {
+    public void testAuthenticateUniversalInstance() throws Exception {
         TestResult tr2 = new TestResult(_wrapper);
 
-        _wrapper.getClient().getAuthenticationService().authenticateUniversal(getUser(Users.UserA).id, getUser(Users.UserA).password, true, tr2);
-        
+        _wrapper.getClient().getAuthenticationService().authenticateUniversal(getUser(Users.UserA).id,
+                getUser(Users.UserA).password, true, tr2);
+
         tr2.Run();
     }
 
     @Test
-    public void testAuthenticateAdvanced() throws Exception
-    {
+    public void testAuthenticateAdvanced() throws Exception {
         TestResult tr = new TestResult(_wrapper);
 
-        // Call it directly on the wrapper. This way we test both the wrapper and the service
+        // Call it directly on the wrapper. This way we test both the wrapper and the
+        // service
         _wrapper.getClient().getAuthenticationService().authenticateAdvanced(
-            AuthenticationType.Universal, 
-            new AuthenticationIds("authAdvancedUser", "authAdvancedPass"),
-            true,
-            "{\"AnswerToEverything\":42}",
-            tr);
-        
+                AuthenticationType.Universal,
+                new AuthenticationIds("authAdvancedUser", "authAdvancedPass"),
+                true,
+                "{\"AnswerToEverything\":42}",
+                tr);
+
         tr.Run();
     }
 
     @Test
-    public void testAuthenticateEmailPassword() throws Exception
-    {
+    public void testAuthenticateEmailPassword() throws Exception {
         TestResult tr = new TestResult(_wrapper);
 
         _wrapper.getClient().getAuthenticationService().authenticateEmailPassword(
-            getUser(Users.UserA).email,
-            getUser(Users.UserA).password,
-            true,
-            tr);
+                getUser(Users.UserA).email,
+                getUser(Users.UserA).password,
+                true,
+                tr);
 
         tr.Run();
     }
 
     @Test
-    public void testAuthenticateHandoff() throws Exception
-    {
+    public void testAuthenticateHandoff() throws Exception {
         String handoffId;
         String handoffToken;
 
@@ -95,9 +89,9 @@ public class AuthenticationServiceTest extends TestFixtureNoAuth
         tr3.Run();
 
         TestResult tr2 = new TestResult(_wrapper);
-        _client.getScriptService().runScript("createHandoffId", 
-        Helpers.createJsonPair("", ""),
-         tr2);
+        _client.getScriptService().runScript("createHandoffId",
+                Helpers.createJsonPair("", ""),
+                tr2);
         tr2.Run();
         handoffId = tr2.m_response.getJSONObject("data").getJSONObject("response").getString("handoffId");
         handoffToken = tr2.m_response.getJSONObject("data").getJSONObject("response").getString("securityToken");
@@ -106,10 +100,9 @@ public class AuthenticationServiceTest extends TestFixtureNoAuth
         _client.getAuthenticationService().authenticateHandoff(handoffId, handoffToken, tr);
         tr.Run();
     }
-    
+
     @Test
-    public void testAuthenticateSettopHandoff() throws Exception
-    {
+    public void testAuthenticateSettopHandoff() throws Exception {
         String handoffCode;
 
         TestResult tr3 = new TestResult(_wrapper);
@@ -118,9 +111,9 @@ public class AuthenticationServiceTest extends TestFixtureNoAuth
         tr3.Run();
 
         TestResult tr2 = new TestResult(_wrapper);
-        _client.getScriptService().runScript("CreateSettopHandoffCode", 
-        Helpers.createJsonPair("", ""),
-         tr2);
+        _client.getScriptService().runScript("CreateSettopHandoffCode",
+                Helpers.createJsonPair("", ""),
+                tr2);
         tr2.Run();
         handoffCode = tr2.m_response.getJSONObject("data").getJSONObject("response").getString("handoffCode");
 
@@ -130,38 +123,32 @@ public class AuthenticationServiceTest extends TestFixtureNoAuth
     }
 
     @Test
-    public void testAuthenticateExternal() throws Exception
-    {
+    public void testAuthenticateExternal() throws Exception {
 
     }
 
     @Test
-    public void testAuthenticateFacebook() throws Exception
-    {
+    public void testAuthenticateFacebook() throws Exception {
 
     }
 
     @Test
-    public void testAuthenticateFacebookLimited() throws Exception
-    {
+    public void testAuthenticateFacebookLimited() throws Exception {
 
     }
 
     @Test
-    public void testAuthenticateGoogle() throws Exception
-    {
+    public void testAuthenticateGoogle() throws Exception {
 
     }
 
     @Test
-    public void testAuthenticateSteam() throws Exception
-    {
+    public void testAuthenticateSteam() throws Exception {
 
     }
 
     @Test
-    public void testAuthenticateTwitter() throws Exception
-    {
+    public void testAuthenticateTwitter() throws Exception {
 
     }
 
@@ -173,8 +160,7 @@ public class AuthenticationServiceTest extends TestFixtureNoAuth
     }
 
     @Test
-    public void testResetEmailPassword() throws Exception
-    {
+    public void testResetEmailPassword() throws Exception {
         String email = "braincloudunittest@gmail.com";
 
         TestResult tr = new TestResult(_wrapper);
@@ -184,8 +170,7 @@ public class AuthenticationServiceTest extends TestFixtureNoAuth
     }
 
     @Test
-    public void testResetEmailPasswordAdvanced() throws Exception
-    {
+    public void testResetEmailPasswordAdvanced() throws Exception {
         TestResult tr2 = new TestResult(_wrapper);
 
         String content = "{\"fromAddress\": \"fromAddress\",\"fromName\": \"fromName\",\"replyToAddress\": \"replyToAddress\",\"replyToName\": \"replyToName\", \"templateId\": \"8f14c77d-61f4-4966-ab6d-0bee8b13d090\",\"subject\": \"subject\",\"body\": \"Body goes here\", \"substitutions\": { \":name\": \"John Doe\",\":resetLink\": \"www.dummuyLink.io\"}, \"categories\": [\"category1\",\"category2\" ]}";
@@ -198,27 +183,29 @@ public class AuthenticationServiceTest extends TestFixtureNoAuth
     }
 
     @Test
-    public void testResetEmailPasswordWithExpiry() throws Exception
-    {
-            TestResult tr2 = new TestResult(_wrapper);
-            _wrapper.getClient().getAuthenticationService().authenticateUniversal("abc", "abc", true, tr2);
-            tr2.Run();
+    public void testResetEmailPasswordWithExpiry() throws Exception {
+        System.out.println("Test: resetEmailPasswordWithExpiry");
+
+        TestResult tr2 = new TestResult(_wrapper);
+        _wrapper.getClient().getAuthenticationService().authenticateUniversal("abc", "abc", true, tr2);
+        tr2.Run();
 
         String email = "braincloudunittest@gmail.com";
 
         TestResult tr = new TestResult(_wrapper);
         _wrapper.getClient().getAuthenticationService().resetEmailPasswordWithExpiry(
-                email, 1 , tr);
+                email, 1, tr);
         tr.Run();
     }
 
     @Test
-    public void testResetEmailPasswordAdvancedWithExpiry() throws Exception
-    {
+    public void testResetEmailPasswordAdvancedWithExpiry() throws Exception {
+        System.out.println("Test: resetEmailPasswordAdvancedWithExpiry");
+
         TestResult tr = new TestResult(_wrapper);
         _wrapper.getClient().getAuthenticationService().authenticateUniversal("abc", "abc", true, tr);
         tr.Run();
-        
+
         TestResult tr2 = new TestResult(_wrapper);
 
         String content = "{\"fromAddress\": \"fromAddress\",\"fromName\": \"fromName\",\"replyToAddress\": \"replyToAddress\",\"replyToName\": \"replyToName\", \"templateId\": \"8f14c77d-61f4-4966-ab6d-0bee8b13d090\",\"subject\": \"subject\",\"body\": \"Body goes here\", \"substitutions\": { \":name\": \"John Doe\",\":resetLink\": \"www.dummuyLink.io\"}, \"categories\": [\"category1\",\"category2\" ]}";
@@ -232,36 +219,54 @@ public class AuthenticationServiceTest extends TestFixtureNoAuth
     }
 
     @Test
-    public void testResetUniversalIdPassword() throws Exception
-    {
+    public void testResetUniversalIdPassword() throws Exception {
+        System.out.println("Test: resetUniversalIdPassword");
+
         TestResult tr2 = new TestResult(_wrapper);
 
-        _wrapper.getClient().getAuthenticationService().authenticateUniversal(getUser(Users.UserB).id, getUser(Users.UserB).password, true, tr2);
-        
+        _wrapper.getClient().getAuthenticationService().authenticateUniversal(
+                getUser(Users.UserB).id,
+                getUser(Users.UserB).password,
+                true,
+                tr2);
+        tr2.Run();
+
+        _wrapper.getClient().getPlayerStateService().updateContactEmail(
+                "braincloudunittest@gmail.com",
+                tr2);
         tr2.Run();
 
         TestResult tr = new TestResult(_wrapper);
+
         _wrapper.getClient().getAuthenticationService().resetUniversalIdPassword(
-        //an example universal ID of userB
-        "userb-1177370719", tr);
+                getUser(Users.UserB).id,
+                tr);
         tr.Run();
     }
 
     @Test
-    public void testResetUniversalIdPasswordAdvanced() throws Exception
-    {
+    public void testResetUniversalIdPasswordAdvanced() throws Exception {
+        System.out.println("Test: resetUniversalIdPasswordAdvanced");
+
         TestResult tr2 = new TestResult(_wrapper);
 
-        _wrapper.getClient().getAuthenticationService().authenticateUniversal(getUser(Users.UserB).id, getUser(Users.UserB).password, true, tr2);
-        
+        _wrapper.getClient().getAuthenticationService().authenticateUniversal(
+                getUser(Users.UserB).id,
+                getUser(Users.UserB).password,
+                true,
+                tr2);
+        tr2.Run();
+
+        _wrapper.getClient().getPlayerStateService().updateContactEmail(
+                "braincloudunittest@gmail.com",
+                tr2);
         tr2.Run();
 
         TestResult tr = new TestResult(_wrapper);
 
-        String content = "{\"templateId\": \"8f14c77d-61f4-4966-ab6d-0bee8b13d090\", \"substitutions\": { \":name\": \"John Doe\",\":resetLink\": \"www.dummuyLink.io\"}, \"categories\": [\"category1\",\"category2\" ]}"; 
+        String content = "{\"templateId\": \"8f14c77d-61f4-4966-ab6d-0bee8b13d090\", \"substitutions\": { \":name\": \"John Doe\",\":resetLink\": \"www.dummuyLink.io\"}, \"categories\": [\"category1\",\"category2\" ]}";
         _wrapper.getClient().getAuthenticationService().resetUniversalIdPasswordAdvanced(
-            //an example universalId of userB
-                "userb-1177370719",
+                getUser(Users.UserB).id,
                 content,
                 tr);
 
@@ -269,190 +274,208 @@ public class AuthenticationServiceTest extends TestFixtureNoAuth
     }
 
     @Test
-    public void testResetUniversalIdPasswordWithExpiry() throws Exception
-    {
+    public void testResetUniversalIdPasswordWithExpiry() throws Exception {
+        System.out.println("Test: resetUniversalIdPasswordWithExpiry");
+
         TestResult tr2 = new TestResult(_wrapper);
 
-        _wrapper.getClient().getAuthenticationService().authenticateUniversal(getUser(Users.UserB).id, getUser(Users.UserB).password, true, tr2);
-        
+        _wrapper.getClient().getAuthenticationService().authenticateUniversal(
+                getUser(Users.UserB).id,
+                getUser(Users.UserB).password,
+                true,
+                tr2);
+        tr2.Run();
+
+        _wrapper.getClient().getPlayerStateService().updateContactEmail(
+                "braincloudunittest@gmail.com",
+                tr2);
         tr2.Run();
 
         TestResult tr = new TestResult(_wrapper);
+
         _wrapper.getClient().getAuthenticationService().resetUniversalIdPasswordWithExpiry(
-        //an example universal ID of userB
-        "userb-1177370719", 1 , tr);
+                getUser(Users.UserB).id,
+                1,
+                tr);
         tr.Run();
     }
 
     @Test
-    public void testResetUniversalIdPasswordAdvancedWithExpiry() throws Exception
-    {
+    public void testResetUniversalIdPasswordAdvancedWithExpiry() throws Exception {
+        System.out.println("Test: resetUniversalIdPasswordAdvancedWithExpiry");
+
         TestResult tr2 = new TestResult(_wrapper);
 
-        _wrapper.getClient().getAuthenticationService().authenticateUniversal(getUser(Users.UserB).id, getUser(Users.UserB).password, true, tr2);
-        
+        _wrapper.getClient().getAuthenticationService().authenticateUniversal(
+                getUser(Users.UserB).id,
+                getUser(Users.UserB).password,
+                true,
+                tr2);
+        tr2.Run();
+
+        _wrapper.getClient().getPlayerStateService().updateContactEmail(
+                "braincloudunittest@gmail.com",
+                tr2);
         tr2.Run();
 
         TestResult tr = new TestResult(_wrapper);
 
-        String content = "{\"templateId\": \"8f14c77d-61f4-4966-ab6d-0bee8b13d090\", \"substitutions\": { \":name\": \"John Doe\",\":resetLink\": \"www.dummuyLink.io\"}, \"categories\": [\"category1\",\"category2\" ]}"; 
+        String content = "{\"templateId\": \"8f14c77d-61f4-4966-ab6d-0bee8b13d090\", \"substitutions\": { \":name\": \"John Doe\",\":resetLink\": \"www.dummuyLink.io\"}, \"categories\": [\"category1\",\"category2\" ]}";
         _wrapper.getClient().getAuthenticationService().resetUniversalIdPasswordAdvancedWithExpiry(
-            //an example universalId of userB
-                "userb-1177370719",
+                getUser(Users.UserB).id,
                 content,
                 1,
                 tr);
-
         tr.Run();
     }
-    
+
     @Test
-    public void testBadSig() throws Exception
-    {
-        //our problem is that users who refresh their app secret via the portal, the client would fail to read the response, and would retry infinitely.
-        //This threatens our servers, because huge numbers of errors related to bad signature show up, and infinitely retry to get out of this error.
-        //Instead of updating the signature via the portal, we will mimic a bad signature from the client.
+    public void testBadSig() throws Exception {
+        // our problem is that users who refresh their app secret via the portal, the
+        // client would fail to read the response, and would retry infinitely.
+        // This threatens our servers, because huge numbers of errors related to bad
+        // signature show up, and infinitely retry to get out of this error.
+        // Instead of updating the signature via the portal, we will mimic a bad
+        // signature from the client.
         Map<String, String> originalAppSecretMap = new HashMap<String, String>();
         originalAppSecretMap.put(m_appId, m_secret);
         originalAppSecretMap.put(m_childAppId, m_childSecret);
         int numRepeatBadSigFailures = 0;
-    
-        // mess up app 
-        Map<String, String> updatedAppSecretMap = new HashMap<String, String>();;
-    
-        for (Map.Entry<String, String> entry : originalAppSecretMap.entrySet())
-        {
+
+        // mess up app
+        Map<String, String> updatedAppSecretMap = new HashMap<String, String>();
+        ;
+
+        for (Map.Entry<String, String> entry : originalAppSecretMap.entrySet()) {
             updatedAppSecretMap.put(entry.getKey(), entry.getValue() + "123");
-        }  
-        /////////////////////Phase 1
-            //first auth
-            TestResult tr1 = new TestResult(_wrapper);
-            _wrapper.getClient().getAuthenticationService().authenticateUniversal(getUser(Users.UserB).id, getUser(Users.UserB).password, true, tr1);
-            if(tr1.Run())
-            {
-               //Check the packet coming in and compare it to the last recevied packet. if they're both -1, we may be in a repeating scenario.
-                if(mostRecentPacket == -1000000 && secondMostRecentPacket == -1000000)
-                {
-                    mostRecentPacket = _wrapper.getClient().getRestClient().getLastReceivedPacketId();
-                }
-                else
-                {
-                    secondMostRecentPacket = mostRecentPacket;
-                    mostRecentPacket = _wrapper.getClient().getRestClient().getLastReceivedPacketId();
-                }
-        
-                //Is there the sign of a repeat?
-                if(mostRecentPacket == -1 && secondMostRecentPacket == -1)
-                {
-                    numRepeatBadSigFailures++;
-                }
-                //we shouldnt expect more than 2 times that most recent and second most recent are both bad sig errors for this test, else its repeating itself. 
-                if (numRepeatBadSigFailures > 2) throw new Exception("Repeating Bad sig errors");
+        }
+        ///////////////////// Phase 1
+        // first auth
+        TestResult tr1 = new TestResult(_wrapper);
+        _wrapper.getClient().getAuthenticationService().authenticateUniversal(getUser(Users.UserB).id,
+                getUser(Users.UserB).password, true, tr1);
+        if (tr1.Run()) {
+            // Check the packet coming in and compare it to the last recevied packet. if
+            // they're both -1, we may be in a repeating scenario.
+            if (mostRecentPacket == -1000000 && secondMostRecentPacket == -1000000) {
+                mostRecentPacket = _wrapper.getClient().getRestClient().getLastReceivedPacketId();
+            } else {
+                secondMostRecentPacket = mostRecentPacket;
+                mostRecentPacket = _wrapper.getClient().getRestClient().getLastReceivedPacketId();
             }
-        
-            //check state
-            _wrapper.getClient().getPlayerStateService().readUserState(tr1);
-        
-        //////////////////////////Phase 2
-            TestResult tr3 = new TestResult(_wrapper);
-            _wrapper.getClient().initializeWithApps(m_serverUrl, m_appId, updatedAppSecretMap, m_appVersion);
-            _wrapper.getClient().getAuthenticationService().authenticateUniversal(getUser(Users.UserB).id, getUser(Users.UserB).password, true, tr3);
-            if(tr3.RunExpectFail(StatusCodes.FORBIDDEN, ReasonCodes.BAD_SIGNATURE))
-            {
-               //Check the packet coming in and compare it to the last recevied packet. if they're both -1, we may be in a repeating scenario.
-               if(mostRecentPacket == -1000000 && secondMostRecentPacket == -1000000)
-               {
-                   mostRecentPacket = _wrapper.getClient().getRestClient().getLastReceivedPacketId();
-               }
-               else
-               {
-                   secondMostRecentPacket = mostRecentPacket;
-                   mostRecentPacket = _wrapper.getClient().getRestClient().getLastReceivedPacketId();
-               }
-        
-                //Is there the sign of a repeat?
-                if(mostRecentPacket == -1 && secondMostRecentPacket == -1)
-                {
-                    numRepeatBadSigFailures++;
-                }
-                //we shouldnt expect more than 2 times that most recent and second most recent are both bad sig errors for this test, else its repeating itself. 
-                if (numRepeatBadSigFailures > 2) throw new Exception("Repeating Bad sig errors");
+
+            // Is there the sign of a repeat?
+            if (mostRecentPacket == -1 && secondMostRecentPacket == -1) {
+                numRepeatBadSigFailures++;
             }
-        
-            //check state
-            _wrapper.getClient().getPlayerStateService().readUserState(tr3);
-        
-            //wait a while
-            Thread.sleep(5 * 1000);
-        
-            /////////////////////Phase 3
-            TestResult tr5 = new TestResult(_wrapper);
-            _wrapper.getClient().initializeWithApps(m_serverUrl, m_appId, originalAppSecretMap, m_appVersion);
-            _wrapper.getClient().getAuthenticationService().authenticateUniversal(getUser(Users.UserB).id, getUser(Users.UserB).password, true, tr5);
-            if(tr5.Run())
-            {
-                //Check the packet coming in and compare it to the last recevied packet. if they're both -1, we may be in a repeating scenario.
-                if(mostRecentPacket == -1000000 && secondMostRecentPacket == -1000000)
-                {
-                   mostRecentPacket = _wrapper.getClient().getRestClient().getLastReceivedPacketId();
-                }
-                else
-                {
-                   secondMostRecentPacket = mostRecentPacket;
-                   mostRecentPacket = _wrapper.getClient().getRestClient().getLastReceivedPacketId();
-                }
-        
-                //Is there the sign of a repeat?
-                if(mostRecentPacket == -1 && secondMostRecentPacket == -1)
-                {
-                    numRepeatBadSigFailures++;
-                }
-                //we shouldnt expect more than 2 times that most recent and second most recent are both bad sig errors for this test, else its repeating itself. 
-                if (numRepeatBadSigFailures > 2) throw new Exception("Repeating Bad sig errors");
+            // we shouldnt expect more than 2 times that most recent and second most recent
+            // are both bad sig errors for this test, else its repeating itself.
+            if (numRepeatBadSigFailures > 2)
+                throw new Exception("Repeating Bad sig errors");
+        }
+
+        // check state
+        _wrapper.getClient().getPlayerStateService().readUserState(tr1);
+
+        ////////////////////////// Phase 2
+        TestResult tr3 = new TestResult(_wrapper);
+        _wrapper.getClient().initializeWithApps(m_serverUrl, m_appId, updatedAppSecretMap, m_appVersion);
+        _wrapper.getClient().getAuthenticationService().authenticateUniversal(getUser(Users.UserB).id,
+                getUser(Users.UserB).password, true, tr3);
+        if (tr3.RunExpectFail(StatusCodes.FORBIDDEN, ReasonCodes.BAD_SIGNATURE)) {
+            // Check the packet coming in and compare it to the last recevied packet. if
+            // they're both -1, we may be in a repeating scenario.
+            if (mostRecentPacket == -1000000 && secondMostRecentPacket == -1000000) {
+                mostRecentPacket = _wrapper.getClient().getRestClient().getLastReceivedPacketId();
+            } else {
+                secondMostRecentPacket = mostRecentPacket;
+                mostRecentPacket = _wrapper.getClient().getRestClient().getLastReceivedPacketId();
             }
-        
-        //check state
+
+            // Is there the sign of a repeat?
+            if (mostRecentPacket == -1 && secondMostRecentPacket == -1) {
+                numRepeatBadSigFailures++;
+            }
+            // we shouldnt expect more than 2 times that most recent and second most recent
+            // are both bad sig errors for this test, else its repeating itself.
+            if (numRepeatBadSigFailures > 2)
+                throw new Exception("Repeating Bad sig errors");
+        }
+
+        // check state
+        _wrapper.getClient().getPlayerStateService().readUserState(tr3);
+
+        // wait a while
+        Thread.sleep(5 * 1000);
+
+        ///////////////////// Phase 3
+        TestResult tr5 = new TestResult(_wrapper);
+        _wrapper.getClient().initializeWithApps(m_serverUrl, m_appId, originalAppSecretMap, m_appVersion);
+        _wrapper.getClient().getAuthenticationService().authenticateUniversal(getUser(Users.UserB).id,
+                getUser(Users.UserB).password, true, tr5);
+        if (tr5.Run()) {
+            // Check the packet coming in and compare it to the last recevied packet. if
+            // they're both -1, we may be in a repeating scenario.
+            if (mostRecentPacket == -1000000 && secondMostRecentPacket == -1000000) {
+                mostRecentPacket = _wrapper.getClient().getRestClient().getLastReceivedPacketId();
+            } else {
+                secondMostRecentPacket = mostRecentPacket;
+                mostRecentPacket = _wrapper.getClient().getRestClient().getLastReceivedPacketId();
+            }
+
+            // Is there the sign of a repeat?
+            if (mostRecentPacket == -1 && secondMostRecentPacket == -1) {
+                numRepeatBadSigFailures++;
+            }
+            // we shouldnt expect more than 2 times that most recent and second most recent
+            // are both bad sig errors for this test, else its repeating itself.
+            if (numRepeatBadSigFailures > 2)
+                throw new Exception("Repeating Bad sig errors");
+        }
+
+        // check state
         _wrapper.getClient().getPlayerStateService().readUserState(tr5);
     }
 
     @Test
-    public void testReInit() throws Exception
-    {
+    public void testReInit() throws Exception {
         Map<String, String> originalAppSecretMap = new HashMap<String, String>();
         originalAppSecretMap.put(m_appId, m_secret);
         originalAppSecretMap.put(m_childAppId, m_childSecret);
 
-        int initCounter = 1; 
+        int initCounter = 1;
 
-        //case 1 Multiple init on client
+        // case 1 Multiple init on client
         _wrapper.getClient().initializeWithApps(m_serverUrl, m_appId, originalAppSecretMap, m_appVersion);
         Assert.assertTrue(initCounter == 1);
         initCounter++;
 
-         _wrapper.getClient().initializeWithApps(m_serverUrl, m_appId, originalAppSecretMap, m_appVersion);
+        _wrapper.getClient().initializeWithApps(m_serverUrl, m_appId, originalAppSecretMap, m_appVersion);
         Assert.assertTrue(initCounter == 2);
         initCounter++;
 
-         _wrapper.getClient().initializeWithApps(m_serverUrl, m_appId, originalAppSecretMap, m_appVersion);
+        _wrapper.getClient().initializeWithApps(m_serverUrl, m_appId, originalAppSecretMap, m_appVersion);
         Assert.assertTrue(initCounter == 3);
 
-        //case 2 
+        // case 2
 
-        //Auth 
+        // Auth
         TestResult tr1 = new TestResult(_wrapper);
-        _wrapper.getClient().getAuthenticationService().authenticateUniversal(getUser(Users.UserB).id, getUser(Users.UserB).password, true, tr1);
+        _wrapper.getClient().getAuthenticationService().authenticateUniversal(getUser(Users.UserB).id,
+                getUser(Users.UserB).password, true, tr1);
         tr1.Run();
 
-        //Call
+        // Call
         TestResult tr2 = new TestResult(_wrapper);
         _wrapper.getTimeService().readServerTime(
                 tr2);
         tr2.Run();
 
-        //reinit
+        // reinit
         _wrapper.getClient().initializeWithApps(m_serverUrl, m_appId, originalAppSecretMap, m_appVersion);
 
-        // //call without auth - expecting it to fail because we need to reauth after init
+        // //call without auth - expecting it to fail because we need to reauth after
+        // init
         TestResult tr3 = new TestResult(_wrapper);
         _wrapper.getTimeService().readServerTime(
                 tr3);
@@ -461,13 +484,14 @@ public class AuthenticationServiceTest extends TestFixtureNoAuth
     }
 
     @Test
-    public void testAuthenticateUltra() throws Exception
-    {
+    public void testAuthenticateUltra() throws Exception {
         if (!getServerUrl().contains("api-internal.braincloudservers.com") &&
-            !getServerUrl().contains("internala.braincloudservers.com") &&
-            !getServerUrl().contains("api.internalg.braincloudservers.com")/* &&
-            !getServerUrl().contains("api.ultracloud.ultra.io")*/)
-        {
+                !getServerUrl().contains("internala.braincloudservers.com") &&
+                !getServerUrl().contains("api.internalg.braincloudservers.com")/*
+                                                                                * &&
+                                                                                * !getServerUrl().contains(
+                                                                                * "api.ultracloud.ultra.io")
+                                                                                */) {
             return;
         }
 
@@ -475,15 +499,16 @@ public class AuthenticationServiceTest extends TestFixtureNoAuth
 
         // Auth universal
         _wrapper.getClient().getAuthenticationService().authenticateEmailPassword(
-            getUser(Users.UserA).email,
-            getUser(Users.UserA).password,
-            true, tr);
+                getUser(Users.UserA).email,
+                getUser(Users.UserA).password,
+                true, tr);
         tr.Run();
 
         // Run a cloud script to grab the ultra's JWT token
         _wrapper.getClient().getScriptService().runScript("getUltraToken", "{}", tr);
         tr.Run();
-        String id_token = tr.m_response.getJSONObject("data").getJSONObject("response").getJSONObject("data").getJSONObject("json").getString("id_token");
+        String id_token = tr.m_response.getJSONObject("data").getJSONObject("response").getJSONObject("data")
+                .getJSONObject("json").getString("id_token");
 
         // Logout
         _wrapper.getClient().getPlayerStateService().logout(tr);
@@ -495,8 +520,7 @@ public class AuthenticationServiceTest extends TestFixtureNoAuth
     }
 
     @Test
-    public void testSmartSwitchAuthenticateEmailFromAnonAuth() throws Exception
-    {
+    public void testSmartSwitchAuthenticateEmailFromAnonAuth() throws Exception {
         // get anon auth
         TestResult tr = new TestResult(_wrapper);
         String anonId = _client.getAuthenticationService().generateAnonymousId();
@@ -510,8 +534,7 @@ public class AuthenticationServiceTest extends TestFixtureNoAuth
     }
 
     @Test
-    public void testSmartSwitchAuthenticateUniversalFromAnon() throws Exception
-    {
+    public void testSmartSwitchAuthenticateUniversalFromAnon() throws Exception {
         // get anon auth
         TestResult tr = new TestResult(_wrapper);
         String anonId = _client.getAuthenticationService().generateAnonymousId();
@@ -525,12 +548,11 @@ public class AuthenticationServiceTest extends TestFixtureNoAuth
     }
 
     @Test
-    public void testSmartSwitchAuthenticateEmailFromUniversal() throws Exception
-    {
+    public void testSmartSwitchAuthenticateEmailFromUniversal() throws Exception {
         String email = "braincloudunittest@gmail.com";
         // get anon auth
         TestResult tr = new TestResult(_wrapper);
-        
+
         _client.getAuthenticationService().authenticateUniversal(email, "12345", true, tr);
 
         tr.Run();

--- a/src/test/java/com/bitheads/braincloud/services/GroupFileServiceTest.java
+++ b/src/test/java/com/bitheads/braincloud/services/GroupFileServiceTest.java
@@ -22,7 +22,7 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
     private static String _groupId = "a7ff751c-3251-407a-b2fd-2bd1e9bca64a";
     private static JSONObject acl = new JSONObject();
     private static boolean uploadSuccess;
-    private static String fileId = "rip";
+    private static String fileId = "";
 
     private String movedFilename = "moved-testfile-java.txt";
     private String copiedFilename = "copied-testfile-java.txt";

--- a/src/test/java/com/bitheads/braincloud/services/GroupFileServiceTest.java
+++ b/src/test/java/com/bitheads/braincloud/services/GroupFileServiceTest.java
@@ -59,6 +59,11 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
                 tr);
         tr.Run();
 
+        /* Add user to test group */
+        System.out.println("Joining test group...");
+    	_wrapper.getGroupService().joinGroup(_groupId, tr);
+    	tr.Run();
+
         _client.registerFileUploadCallback(new IFileUploadCallback() {
 
             @Override
@@ -86,7 +91,7 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
             file.deleteOnExit();
         } catch (IOException e) {
             System.out.println("Error creating/locating '" + _tempFilename + "'");
-            throw new RuntimeException(e);
+            e.printStackTrace();
         }
 
         // Upload the file
@@ -107,7 +112,8 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
 
                 waitForReturn(new String[] { id }, false);
             } catch (Exception e) {
-                throw new RuntimeException(e);
+                System.out.println("Error reading upload ID");
+                e.printStackTrace();
             }
         }
         assertTrue(uploadSuccess);
@@ -117,11 +123,12 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
             acl.put("other", 0);
             acl.put("member", 2);
         } catch (JSONException e) {
-            throw new RuntimeException(e);
+            System.out.println("Error creaing acl json object");
+            e.printStackTrace();
         }
 
         /* moveUserToGroupFile Test */
-        System.out.println("Moving file...");
+        System.out.println("moveUserToGroupFile");
         _wrapper.getGroupFileService().moveUserToGroupFile(
                 "TestFolder/",
                 _tempFilename,
@@ -139,7 +146,8 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
             fileDetails = data.getJSONObject("fileDetails");
             fileId = fileDetails.getString("fileId");
         } catch (JSONException e) {
-            throw new RuntimeException(e);
+            System.out.println("Error saving group file ID");
+            e.printStackTrace();
         }
     }
 
@@ -166,7 +174,7 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
 
     @Test
     public void testCheckFilenameExists() {
-        System.out.println("testCheckFilenameExists");
+        System.out.println("checkFilenameExists");
 
         TestResult tr = new TestResult(_wrapper);
         JSONObject data;
@@ -187,7 +195,7 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
 
     @Test
     public void testCheckFullpathFilenameExists() {
-        System.out.println("testCheckFullpathFilenameExists");
+        System.out.println("checkFullpathFilenameExists");
 
         TestResult tr = new TestResult(_wrapper);
         JSONObject data;
@@ -208,7 +216,7 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
 
     @Test
     public void testGetFileInfo() {
-        System.out.println("testGetFileInfo");
+        System.out.println("getFileInfo");
 
         TestResult tr = new TestResult(_wrapper);
 
@@ -218,7 +226,7 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
 
     @Test
     public void testGetFileInfoSimple() {
-        System.out.println("testGetFileInfoSimple");
+        System.out.println("getFileInfoSimple");
         
         TestResult tr = new TestResult(_wrapper);
 
@@ -228,7 +236,7 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
 
     @Test
     public void testGetCDNUrl() {
-        System.out.println("testGetCDNUrl");
+        System.out.println("getCDNUrl");
 
         TestResult tr = new TestResult(_wrapper);
 
@@ -238,7 +246,7 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
 
     @Test
     public void testGetFileList() {
-        System.out.println("testGetFileList");
+        System.out.println("getFileList");
 
         TestResult tr = new TestResult(_wrapper);
         _wrapper.getGroupFileService().getFileList(_groupId, "", true, tr);
@@ -247,7 +255,7 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
 
     @Test
     public void testMoveFile(){
-        System.out.println("testMoveFile");
+        System.out.println("moveFile");
         
         TestResult tr = new TestResult(_wrapper);
 
@@ -264,7 +272,7 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
         tr.Run();
 
         // Revert back
-        System.out.println("Moving back...");
+        System.out.println("Moving file back");
         _wrapper.getGroupFileService().moveFile(
                 _groupId,
                 fileId,
@@ -280,12 +288,12 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
 
     @Test
     public void testCopyFile(){
+        System.out.println("copyFile");
+        
         TestResult tr = new TestResult(_wrapper);
         JSONObject data;
         JSONObject fileDetails;
         String copiedFileId;
-
-        System.out.println("testCopyFile...");
 
         _wrapper.getGroupFileService().copyFile(
                 _groupId,
@@ -316,13 +324,14 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
             );
             tr.Run();
         } catch (JSONException e) {
+            System.out.println("Error saving copied group file ID");
             e.printStackTrace();
         }
     }
 
     @Test
     public void testUpdateFileInfo(){
-        System.out.println("testUpdateFileInfo");
+        System.out.println("updateFileInfo");
         
         TestResult tr = new TestResult(_wrapper);
         JSONObject acl = new JSONObject();
@@ -332,10 +341,10 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
             acl.put("other", 0);
             acl.put("member", 2);
         } catch (JSONException e) {
-            throw new RuntimeException(e);
+            System.out.println("Error creating acl json object");
+            e.printStackTrace();
         }
 
-        System.out.println("Updating file info...");
         _wrapper.getGroupFileService().updateFileInfo(
                 _groupId,
                 fileId,
@@ -347,7 +356,7 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
         tr.Run();
 
         // Revert back
-        System.out.println("Reverting back...");
+        System.out.println("Reverting updated file back");
         _wrapper.getGroupFileService().updateFileInfo(
                 _groupId,
                 fileId,

--- a/src/test/java/com/bitheads/braincloud/services/GroupFileServiceTest.java
+++ b/src/test/java/com/bitheads/braincloud/services/GroupFileServiceTest.java
@@ -1,65 +1,48 @@
 package com.bitheads.braincloud.services;
 
-import com.bitheads.braincloud.client.BrainCloudWrapper;
-import com.bitheads.braincloud.client.IFileUploadCallback;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
 
-public class GroupFileServiceTest extends TestFixtureNoAuth {
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
 
-    private static String _tempFilename = "testfile-java.txt";
-    private static String _groupId = "a7ff751c-3251-407a-b2fd-2bd1e9bca64a";
-    private static JSONObject acl = new JSONObject();
-    private static boolean uploadSuccess;
-    private static String fileId = "";
+import com.bitheads.braincloud.client.IFileUploadCallback;
 
-    private String movedFilename = "moved-testfile-java.txt";
-    private String copiedFilename = "copied-testfile-java.txt";
-    private String updatedFilename = "updated-testfile-java.txt";
+public class GroupFileServiceTest extends TestFixtureBase {
 
-    /**
-     * Creates and uploads a temporary file to be used for each of the Group File
-     * tests.
-     * Also acts as a test for the moveUserToGroupFile method.
-     * If the file fails to upload or get moved to the group, the other tests should
-     * also fail.
-     */
-    @BeforeClass
-    public static void uploadTestFile() {
-        JSONObject data;
-        JSONObject fileDetails;
-
-        /* From setup() in TestFixtureBase.java */
-        _wrapper = new BrainCloudWrapper();
-        _client = _wrapper.getClient();
+    private boolean uploadSuccess;
+    
+    @Test
+    public void oneBigTest() {
         TestResult tr = new TestResult(_wrapper);
+        String tempFilename = "testfile-java.txt";
+        String groupId = "a7ff751c-3251-407a-b2fd-2bd1e9bca64a";
+        String fileId = "";
+        String movedFilename = "moved-testfile-java.txt";
+        String copiedFilename = "copied-testfile-java.txt";
+        String copiedFileId = "";
+        String updatedFilename = "updated-testfile-java.txt";
+        JSONObject acl = new JSONObject();
 
-        m_secretMap = new HashMap<String, String>();
-        m_secretMap.put(m_appId, m_secret);
-        m_secretMap.put(m_childAppId, m_childSecret);
+        // Create acl json object
+        try {
+            acl.put("other", 0);
+            acl.put("member", 2);
+        } catch (JSONException e) {
+            System.out.println("Error creating acl json object");
+            e.printStackTrace();
+        }
 
-        _client.initializeWithApps(m_serverUrl, m_appId, m_secretMap, m_appVersion);
-
-        /* Authenticate */
-        _wrapper.getClient().getAuthenticationService().authenticateUniversal(
-                "java-tester",
-                "java-tester",
-                true,
-                tr);
-        tr.Run();
-
-        _client.registerFileUploadCallback(new IFileUploadCallback() {
+        /* Add user to test group */
+        System.out.println("Joining test group...");
+    	_wrapper.getGroupService().joinGroup(groupId, tr);
+    	tr.Run();
+        
+        /* Create and upload a temporary file */
+        _wrapper.getClient().registerFileUploadCallback(new IFileUploadCallback() {
 
             @Override
             public void fileUploadCompleted(String fileUploadId, String jsonResponse) {
@@ -73,10 +56,9 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
             }
         });
 
-        /* Create and upload a temporary file */
         // Create the file
         System.out.println("Creating file...");
-        File file = new File(_tempFilename);
+        File file = new File(tempFilename);
         try {
             if (file.createNewFile()) {
                 System.out.println("File created.");
@@ -85,18 +67,18 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
             }
             file.deleteOnExit();
         } catch (IOException e) {
-            System.out.println("Error creating/locating '" + _tempFilename + "'");
-            throw new RuntimeException(e);
+            System.out.println("Error creating/locating '" + tempFilename + "'");
+            e.printStackTrace();
         }
 
         // Upload the file
         System.out.println("Uploading file...");
         _wrapper.getFileService().uploadFile(
                 "TestFolder",
-                _tempFilename,
+                tempFilename,
                 true,
                 true,
-                _tempFilename,
+                tempFilename,
                 tr);
         tr.Run();
 
@@ -112,22 +94,14 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
         }
         assertTrue(uploadSuccess);
 
-        // Create acl json object
-        try {
-            acl.put("other", 0);
-            acl.put("member", 2);
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
-        }
-
-        /* moveUserToGroupFile Test */
-        System.out.println("Moving file...");
+        /* Test: moveUserToGroupFile */
+        System.out.println("Test: moveUserToGroupFile");
         _wrapper.getGroupFileService().moveUserToGroupFile(
                 "TestFolder/",
-                _tempFilename,
-                _groupId,
+                tempFilename,
+                groupId,
                 "",
-                _tempFilename,
+                tempFilename,
                 acl,
                 true,
                 tr);
@@ -135,124 +109,68 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
 
         /* Save group file ID for tests */
         try {
-            data = tr.m_response.getJSONObject("data");
-            fileDetails = data.getJSONObject("fileDetails");
+            JSONObject data = tr.m_response.getJSONObject("data");
+            JSONObject fileDetails = data.getJSONObject("fileDetails");
             fileId = fileDetails.getString("fileId");
         } catch (JSONException e) {
-            throw new RuntimeException(e);
+            e.printStackTrace();
         }
-    }
 
-    @AfterClass
-    public static void groupFileTearDown() {
-        _client.deregisterFileUploadCallback();
-    }
+        /* Test: checkFilenameExists */
+        System.out.println("Test: checkFilenameExists");
 
-    /**
-     * Authenticate a user that has been added to a group.
-     */
-    @Before
-    public void groupFileAuthenticate() {
-        TestResult tr = new TestResult(_wrapper);
-
-        /* Authenticate */
-        _wrapper.getClient().getAuthenticationService().authenticateUniversal(
-                "java-tester",
-                "java-tester",
-                true,
-                tr);
-        tr.Run();
-    }
-
-    @Test
-    public void testCheckFilenameExists() {
-        System.out.println("testCheckFilenameExists");
-
-        TestResult tr = new TestResult(_wrapper);
-        JSONObject data;
-        boolean exists;
-
-        _wrapper.getGroupFileService().checkFilenameExists(_groupId, "", _tempFilename, tr);
+        _wrapper.getGroupFileService().checkFilenameExists(groupId, "", tempFilename, tr);
         tr.Run();
 
         // Confirm that the file exists
         try {
-            data = tr.m_response.getJSONObject("data");
-            exists = data.getBoolean("exists");
+            JSONObject data = tr.m_response.getJSONObject("data");
+            boolean exists = data.getBoolean("exists");
+
+            assertTrue(exists);
         } catch (JSONException e) {
-            throw new RuntimeException(e);
+            e.printStackTrace();;
         }
-        assertTrue(exists);
-    }
 
-    @Test
-    public void testCheckFullpathFilenameExists() {
-        System.out.println("testCheckFullpathFilenameExists");
-
-        TestResult tr = new TestResult(_wrapper);
-        JSONObject data;
-        boolean exists;
-
-        _wrapper.getGroupFileService().checkFullpathFilenameExists(_groupId, _tempFilename, tr);
+        /* Test: checkFullpathFilenameExists */
+        System.out.println("Test: checkFullpathFilenameExists");
+        _wrapper.getGroupFileService().checkFullpathFilenameExists(groupId, tempFilename, tr);
         tr.Run();
 
         // Confirm that the file exists
         try {
-            data = tr.m_response.getJSONObject("data");
-            exists = data.getBoolean("exists");
+            JSONObject data = tr.m_response.getJSONObject("data");
+            boolean exists = data.getBoolean("exists");
+
+            assertTrue(exists);
         } catch (JSONException e) {
-            throw new RuntimeException(e);
+            e.printStackTrace();
         }
-        assertTrue(exists);
-    }
 
-    @Test
-    public void testGetFileInfo() {
-        System.out.println("testGetFileInfo");
-
-        TestResult tr = new TestResult(_wrapper);
-
-        _wrapper.getGroupFileService().getFileInfo(_groupId, fileId, tr);
+        /* Test: getFileInfo */
+        System.out.println("Test: getFileInfo");
+        _wrapper.getGroupFileService().getFileInfo(groupId, fileId, tr);
         tr.Run();
-    }
 
-    @Test
-    public void testGetFileInfoSimple() {
-        System.out.println("testGetFileInfoSimple");
-        
-        TestResult tr = new TestResult(_wrapper);
-
-        _wrapper.getGroupFileService().getFileInfoSimple(_groupId, "", _tempFilename, tr);
+        /* Test: getFileInfoSimple */
+        System.out.println("Test: getFileInfoSimple");
+        _wrapper.getGroupFileService().getFileInfoSimple(groupId, "", tempFilename, tr);
         tr.Run();
-    }
 
-    @Test
-    public void testGetCDNUrl() {
-        System.out.println("testGetCDNUrl");
-
-        TestResult tr = new TestResult(_wrapper);
-
-        _wrapper.getGroupFileService().getCDNUrl(_groupId, fileId, tr);
+        /* Test: getCDNUrl */
+        System.out.println("Test: getCDNUrl");
+        _wrapper.getGroupFileService().getCDNUrl(groupId, fileId, tr);
         tr.Run();
-    }
 
-    @Test
-    public void testGetFileList() {
-        System.out.println("testGetFileList");
-
-        TestResult tr = new TestResult(_wrapper);
-        _wrapper.getGroupFileService().getFileList(_groupId, "", true, tr);
+        /* Test: getFileList */
+        System.out.println("Test: getFileList");
+        _wrapper.getGroupFileService().getFileList(groupId, "", true, tr);
         tr.Run();
-    }
 
-    @Test
-    public void testMoveFile(){
-        System.out.println("testMoveFile");
-        
-        TestResult tr = new TestResult(_wrapper);
-
+        /* Test: moveFile */
+        System.out.println("Test: moveFile");
         _wrapper.getGroupFileService().moveFile(
-                _groupId,
+                groupId,
                 fileId,
                 -1,
                 "",
@@ -266,29 +184,21 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
         // Revert back
         System.out.println("Moving back...");
         _wrapper.getGroupFileService().moveFile(
-                _groupId,
+                groupId,
                 fileId,
                 -1,
                 "",
                 0,
-                _tempFilename,
+                tempFilename,
                 true,
                 tr
         );
         tr.Run();
-    }
 
-    @Test
-    public void testCopyFile(){
-        TestResult tr = new TestResult(_wrapper);
-        JSONObject data;
-        JSONObject fileDetails;
-        String copiedFileId;
-
-        System.out.println("testCopyFile...");
-
+        /* Test: copyFile */
+        System.out.println("Test: copyFile");
         _wrapper.getGroupFileService().copyFile(
-                _groupId,
+                groupId,
                 fileId,
                 -1,
                 "",
@@ -301,43 +211,29 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
 
         // Save data from copied file
         try {
-            data = tr.m_response.getJSONObject("data");
-            fileDetails = data.getJSONObject("fileDetails");
+            JSONObject data = tr.m_response.getJSONObject("data");
+            JSONObject fileDetails = data.getJSONObject("fileDetails");
             copiedFileId = fileDetails.getString("fileId");
-
-            // Delete new file
-            System.out.println("Deleting new file...");
-            _wrapper.getGroupFileService().deleteFile(
-                    _groupId,
-                    copiedFileId,
-                    -1,
-                    copiedFilename,
-                    tr
-            );
-            tr.Run();
         } catch (JSONException e) {
             e.printStackTrace();
         }
-    }
 
-    @Test
-    public void testUpdateFileInfo(){
-        System.out.println("testUpdateFileInfo");
-        
-        TestResult tr = new TestResult(_wrapper);
-        JSONObject acl = new JSONObject();
+        /* Test: deleteFile */
+        // Delete file from copyFile test
+        System.out.println("Test: deleteFile");
+        _wrapper.getGroupFileService().deleteFile(
+                groupId,
+                copiedFileId,
+                -1,
+                copiedFilename,
+                tr
+        );
+        tr.Run();
 
-        // Create acl json object
-        try {
-            acl.put("other", 0);
-            acl.put("member", 2);
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
-        }
-
-        System.out.println("Updating file info...");
+        /* Test: updateFileInfo */
+        System.out.println("Test: updateFileInfo");
         _wrapper.getGroupFileService().updateFileInfo(
-                _groupId,
+                groupId,
                 fileId,
                 -1,
                 updatedFilename,
@@ -349,18 +245,20 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
         // Revert back
         System.out.println("Reverting back...");
         _wrapper.getGroupFileService().updateFileInfo(
-                _groupId,
+                groupId,
                 fileId,
                 -1,
-                _tempFilename,
+                tempFilename,
                 acl,
                 tr
         );
         tr.Run();
+
+        _wrapper.getClient().deregisterFileUploadCallback();
     }
 
     /* Taken from FileServiceTest. */
-    private static void waitForReturn(String[] uploadIds, Boolean cancelUpload) throws Exception {
+    private void waitForReturn(String[] uploadIds, Boolean cancelUpload) throws Exception {
         FileService service = _wrapper.getFileService();
         int count = 0;
         Boolean sw = true;
@@ -390,8 +288,7 @@ public class GroupFileServiceTest extends TestFixtureNoAuth {
         }
     }
 
-    private static String getUploadId(JSONObject response) throws Exception {
+    private String getUploadId(JSONObject response) throws Exception {
         return response.getJSONObject("data").getJSONObject("fileDetails").getString("uploadId");
     }
-
 }

--- a/src/test/java/com/bitheads/braincloud/services/GroupFileServiceTest.java
+++ b/src/test/java/com/bitheads/braincloud/services/GroupFileServiceTest.java
@@ -16,7 +16,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 
-public class GroupFileServiceTest extends TestFixtureBase {
+public class GroupFileServiceTest extends TestFixtureNoAuth {
 
     private static String _tempFilename = "testfile-java.txt";
     private static String _groupId = "a7ff751c-3251-407a-b2fd-2bd1e9bca64a";
@@ -36,7 +36,7 @@ public class GroupFileServiceTest extends TestFixtureBase {
      * also fail.
      */
     @BeforeClass
-    public static void groupFileSetup() {
+    public static void uploadTestFile() {
         JSONObject data;
         JSONObject fileDetails;
 
@@ -51,7 +51,13 @@ public class GroupFileServiceTest extends TestFixtureBase {
 
         _client.initializeWithApps(m_serverUrl, m_appId, m_secretMap, m_appVersion);
 
-        //TODO
+        /* Authenticate */
+        _wrapper.getClient().getAuthenticationService().authenticateUniversal(
+                "java-tester",
+                "java-tester",
+                true,
+                tr);
+        tr.Run();
 
         _client.registerFileUploadCallback(new IFileUploadCallback() {
 

--- a/src/test/java/com/bitheads/braincloud/services/GroupFileServiceTest.java
+++ b/src/test/java/com/bitheads/braincloud/services/GroupFileServiceTest.java
@@ -1,235 +1,118 @@
 package com.bitheads.braincloud.services;
 
+import com.bitheads.braincloud.client.BrainCloudWrapper;
 import com.bitheads.braincloud.client.IFileUploadCallback;
 
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.Assert;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.util.HashMap;
 
-public class GroupFileServiceTest extends TestFixtureNoAuth implements IFileUploadCallback {
+public class GroupFileServiceTest extends TestFixtureNoAuth {
 
-    /* Information grabbed from internal servers -> Unit Test Master */
-    //id for testingGroupFile.dat
-    private String groupFileId = "d2dd646a-f1af-4a96-90a7-a0310246f5a2";
-    private String groupID = "a7ff751c-3251-407a-b2fd-2bd1e9bca64a";
+    private static String _tempFilename = "testfile-java.txt";
+    private static String _groupId = "a7ff751c-3251-407a-b2fd-2bd1e9bca64a";
+    private static JSONObject acl = new JSONObject();
+    private static boolean uploadSuccess;
+    private static String fileId = "rip";
 
-    //Making version a negative value to tell the server to use the latest version
-    private int version = -1;
-    private int _returnCount;
-    private int _failCount;
-    private String filename = "testingGroupFile.dat";
-    String newFileName = "testCopiedFile.dat";
-    private String tempFilename = "deleteThisFileAfter.dat";
-    private String updatedName = "UpdatedGroupFile.dat";
+    private String movedFilename = "moved-testfile-java.txt";
+    private String copiedFilename = "copied-testfile-java.txt";
+    private String updatedFilename = "updated-testfile-java.txt";
 
-    @Test
-    public void testCheckFilenameExists(){
-        TestResult tr = new TestResult(_wrapper);
-        JSONObject data;
-        boolean exists;
-
-        System.out.println("testCheckFilenameExists...");
-
-        System.out.println("Authenticating...");
-        _wrapper.getClient().getAuthenticationService().authenticateUniversal(
-                "java-tester",
-                "java-tester",
-                true,
-                tr
-        );
-        tr.Run();
-
-        System.out.println("Checking if file exists...");
-        _wrapper.getGroupFileService().checkFilenameExists(groupID, "", filename, tr);
-        tr.Run();
-
-        //Confirm that file exists
-        try {
-            data = tr.m_response.getJSONObject("data");
-            exists = data.getBoolean("exists");
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
-        }
-        Assert.assertTrue(exists);
-    }
-
-    @Test
-    public void testCheckFullpathFilenameExists(){
-        TestResult tr = new TestResult(_wrapper);
-        JSONObject data;
-        boolean exists;
-
-        System.out.println("testCheckFullpathFilenameExists...");
-
-        System.out.println("Authenticating...");
-        _wrapper.getClient().getAuthenticationService().authenticateUniversal(
-                "java-tester",
-                "java-tester",
-                true,
-                tr
-        );
-        tr.Run();
-
-        System.out.println("Checking if file exists...");
-        _wrapper.getGroupFileService().checkFullpathFilenameExists(groupID, filename, tr);
-        tr.Run();
-
-        //Confirm that file exists
-        try {
-            data = tr.m_response.getJSONObject("data");
-            exists = data.getBoolean("exists");
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
-        }
-        Assert.assertTrue(exists);
-    }
-
-    @Test
-    public void testGetFileInfo(){
-        TestResult tr = new TestResult(_wrapper);
-
-        System.out.println("testGetFileInfo...");
-
-        _wrapper.getClient().getAuthenticationService().authenticateUniversal(
-                "java-tester",
-                "java-tester",
-                true,
-                tr
-        );
-        tr.Run();
-
-        System.out.println("Getting file info...");
-        _wrapper.getGroupFileService().getFileInfo(groupID, groupFileId, tr);
-        tr.Run();
-
-        //testGetCDNUrl
-        System.out.println("Getting CDN URL...");
-        _wrapper.getGroupFileService().getCDNUrl(groupID, groupFileId, tr);
-        tr.Run();
-    }
-
-    @Test
-    public void testGetFileInfoSimple(){
-        TestResult tr = new TestResult(_wrapper);
-
-        System.out.println("testGetFileInfoSimple...");
-
-        System.out.println("Authenticating...");
-        _wrapper.getClient().getAuthenticationService().authenticateUniversal(
-                "java-tester",
-                "java-tester",
-                true,
-                tr
-        );
-        tr.Run();
-
-        System.out.println("Getting file info...");
-        _wrapper.getGroupFileService().getFileInfoSimple(groupID, "", filename, tr);
-        tr.Run();
-    }
-
-    @Test
-    public void testGetFileList(){
-        TestResult tr = new TestResult(_wrapper);
-
-        System.out.println("testGetFileList...");
-
-        System.out.println("Authenticating...");
-        _wrapper.getClient().getAuthenticationService().authenticateUniversal(
-                "java-tester",
-                "java-tester",
-                true,
-                tr
-        );
-        tr.Run();
-
-        System.out.println("Getting file list...");
-        boolean recurse = true;
-        _wrapper.getGroupFileService().getFileList(groupID, "", recurse, tr);
-        tr.Run();
-    }
-
-    @Test
-    public void testMoveFile(){
-        TestResult tr = new TestResult(_wrapper);
-
-        System.out.println("testMoveFile...");
-
-        System.out.println("Authenticating...");
-        _wrapper.getClient().getAuthenticationService().authenticateUniversal(
-                "java-tester",
-                "java-tester",
-                true,
-                tr
-        );
-        tr.Run();
-
-        System.out.println("Moving file...");
-        _wrapper.getGroupFileService().moveFile(
-                groupID,
-                groupFileId,
-                version,
-                "",
-                0,
-                newFileName,
-                true,
-                tr
-        );
-        tr.Run();
-
-        //Revert back
-        System.out.println("Moving back...");
-        _wrapper.getGroupFileService().moveFile(
-                groupID,
-                groupFileId,
-                version,
-                "",
-                0,
-                filename,
-                true,
-                tr
-        );
-        tr.Run();
-    }
-
-    @Test
-    public void testMoveUserToGroupFile(){
-        TestResult tr = new TestResult(_wrapper);
-        JSONObject acl = new JSONObject();
+    /**
+     * Creates and uploads a temporary file to be used for each of the Group File
+     * tests.
+     * Also acts as a test for the moveUserToGroupFile method.
+     * If the file fails to upload or get moved to the group, the other tests should
+     * also fail.
+     */
+    @BeforeClass
+    public static void uploadTestFile() {
         JSONObject data;
         JSONObject fileDetails;
-        String newFileId;
 
-        System.out.println("testMoveUserToGroupFile...");
+        /* From setup() in TestFixtureBase.java */
+        _wrapper = new BrainCloudWrapper();
+        _client = _wrapper.getClient();
+        TestResult tr = new TestResult(_wrapper);
 
-        _wrapper.getClient().registerFileUploadCallback(this);
+        m_secretMap = new HashMap<String, String>();
+        m_secretMap.put(m_appId, m_secret);
+        m_secretMap.put(m_childAppId, m_childSecret);
 
-        System.out.println("Authenticating...");
-        _wrapper.getClient().getAuthenticationService().authenticateUniversal("java-tester", "java-tester", true, tr);
+        _client.initializeWithApps(m_serverUrl, m_appId, m_secretMap, m_appVersion);
+
+        /* Authenticate */
+        _wrapper.getClient().getAuthenticationService().authenticateUniversal(
+                "java-tester",
+                "java-tester",
+                true,
+                tr);
         tr.Run();
 
-        /* Upload a new file */
-        //Create the file
-        System.out.println("Creating file...");
-        File file = new File(tempFilename);
-        try {
-            if(file.createNewFile()){
-                System.out.println("File created.");
+        _client.registerFileUploadCallback(new IFileUploadCallback() {
+
+            @Override
+            public void fileUploadCompleted(String fileUploadId, String jsonResponse) {
+                System.out.println("Temporary file uploaded successfully");
+                uploadSuccess = true;
             }
-            else{
+
+            @Override
+            public void fileUploadFailed(String fileUploadId, int statusCode, int reasonCode, String jsonResponse) {
+                System.out.println("Temporary file failed to upload");
+            }
+        });
+
+        /* Create and upload a temporary file */
+        // Create the file
+        System.out.println("Creating file...");
+        File file = new File(_tempFilename);
+        try {
+            if (file.createNewFile()) {
+                System.out.println("File created.");
+            } else {
                 System.out.println("File already exists...");
             }
+            file.deleteOnExit();
         } catch (IOException e) {
-            System.out.println("Error creating/locating '" + tempFilename + "'");
+            System.out.println("Error creating/locating '" + _tempFilename + "'");
             throw new RuntimeException(e);
         }
 
-        //Create acl json object
+        // Upload the file
+        System.out.println("Uploading file...");
+        _wrapper.getFileService().uploadFile(
+                "TestFolder",
+                _tempFilename,
+                true,
+                true,
+                _tempFilename,
+                tr);
+        tr.Run();
+
+        // Wait for upload to complete
+        if (tr.m_result) {
+            try {
+                String id = getUploadId(tr.m_response);
+
+                waitForReturn(new String[] { id }, false);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        assertTrue(uploadSuccess);
+
+        // Create acl json object
         try {
             acl.put("other", 0);
             acl.put("member", 2);
@@ -237,78 +120,162 @@ public class GroupFileServiceTest extends TestFixtureNoAuth implements IFileUplo
             throw new RuntimeException(e);
         }
 
-        //Upload the file
-        System.out.println("Uploading file...");
-        boolean _shareable = true;
-        boolean _replaceIfExists = true;
-        _wrapper.getFileService().uploadFile(
-                "TestFolder",
-                tempFilename,
-                _shareable,
-                _replaceIfExists,
-                tempFilename,
-                tr
-        );
-        tr.Run();
-
-        //Wait for upload to complete
-        if (tr.m_result) {
-            try {
-                String id = getUploadId(tr.m_response);
-
-                waitForReturn(new String[]{id}, false);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
-        Assert.assertEquals(0, _failCount);
-
-        //Move file
+        /* moveUserToGroupFile Test */
         System.out.println("Moving file...");
         _wrapper.getGroupFileService().moveUserToGroupFile(
                 "TestFolder/",
-                tempFilename,
-                groupID,
+                _tempFilename,
+                _groupId,
                 "",
-                tempFilename,
+                _tempFilename,
                 acl,
+                true,
+                tr);
+        tr.Run();
+
+        /* Save group file ID for tests */
+        try {
+            data = tr.m_response.getJSONObject("data");
+            fileDetails = data.getJSONObject("fileDetails");
+            fileId = fileDetails.getString("fileId");
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @AfterClass
+    public static void groupFileTearDown() {
+        _client.deregisterFileUploadCallback();
+    }
+
+    /**
+     * Authenticate a user that has been added to a group.
+     */
+    @Before
+    public void groupFileAuthenticate() {
+        TestResult tr = new TestResult(_wrapper);
+
+        /* Authenticate */
+        _wrapper.getClient().getAuthenticationService().authenticateUniversal(
+                "java-tester",
+                "java-tester",
+                true,
+                tr);
+        tr.Run();
+    }
+
+    @Test
+    public void testCheckFilenameExists() {
+        System.out.println("testCheckFilenameExists");
+
+        TestResult tr = new TestResult(_wrapper);
+        JSONObject data;
+        boolean exists;
+
+        _wrapper.getGroupFileService().checkFilenameExists(_groupId, "", _tempFilename, tr);
+        tr.Run();
+
+        // Confirm that the file exists
+        try {
+            data = tr.m_response.getJSONObject("data");
+            exists = data.getBoolean("exists");
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+        assertTrue(exists);
+    }
+
+    @Test
+    public void testCheckFullpathFilenameExists() {
+        System.out.println("testCheckFullpathFilenameExists");
+
+        TestResult tr = new TestResult(_wrapper);
+        JSONObject data;
+        boolean exists;
+
+        _wrapper.getGroupFileService().checkFullpathFilenameExists(_groupId, _tempFilename, tr);
+        tr.Run();
+
+        // Confirm that the file exists
+        try {
+            data = tr.m_response.getJSONObject("data");
+            exists = data.getBoolean("exists");
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+        assertTrue(exists);
+    }
+
+    @Test
+    public void testGetFileInfo() {
+        System.out.println("testGetFileInfo");
+
+        TestResult tr = new TestResult(_wrapper);
+
+        _wrapper.getGroupFileService().getFileInfo(_groupId, fileId, tr);
+        tr.Run();
+    }
+
+    @Test
+    public void testGetFileInfoSimple() {
+        System.out.println("testGetFileInfoSimple");
+        
+        TestResult tr = new TestResult(_wrapper);
+
+        _wrapper.getGroupFileService().getFileInfoSimple(_groupId, "", _tempFilename, tr);
+        tr.Run();
+    }
+
+    @Test
+    public void testGetCDNUrl() {
+        System.out.println("testGetCDNUrl");
+
+        TestResult tr = new TestResult(_wrapper);
+
+        _wrapper.getGroupFileService().getCDNUrl(_groupId, fileId, tr);
+        tr.Run();
+    }
+
+    @Test
+    public void testGetFileList() {
+        System.out.println("testGetFileList");
+
+        TestResult tr = new TestResult(_wrapper);
+        _wrapper.getGroupFileService().getFileList(_groupId, "", true, tr);
+        tr.Run();
+    }
+
+    @Test
+    public void testMoveFile(){
+        System.out.println("testMoveFile");
+        
+        TestResult tr = new TestResult(_wrapper);
+
+        _wrapper.getGroupFileService().moveFile(
+                _groupId,
+                fileId,
+                -1,
+                "",
+                0,
+                movedFilename,
                 true,
                 tr
         );
         tr.Run();
 
-        try{
-            data = tr.m_response.getJSONObject("data");
-            fileDetails = data.getJSONObject("fileDetails");
-            newFileId = fileDetails.getString("fileId");
-        } catch (JSONException e){
-            throw new RuntimeException(e);
-        }
-
-        //Delete new file
-        System.out.println("Deleting file...");
-        _wrapper.getGroupFileService().deleteFile(
-                groupID,
-                newFileId,
-                version,
-                tempFilename,
+        // Revert back
+        System.out.println("Moving back...");
+        _wrapper.getGroupFileService().moveFile(
+                _groupId,
+                fileId,
+                -1,
+                "",
+                0,
+                _tempFilename,
+                true,
                 tr
         );
         tr.Run();
-        
-        try {
-        	if(file.delete()) {
-            	System.out.println("Temporary file has been deleted from workspace.");
-            }
-            else {
-            	System.out.println("Failed to delete temporary file from workspace...");
-            }
-        } catch(Exception e) {
-        	System.out.println("Error attempting to delete temporary file from workspace...");
-        	e.printStackTrace();
-        }
-
-        _wrapper.getClient().deregisterFileUploadCallback();
     }
 
     @Test
@@ -316,39 +283,35 @@ public class GroupFileServiceTest extends TestFixtureNoAuth implements IFileUplo
         TestResult tr = new TestResult(_wrapper);
         JSONObject data;
         JSONObject fileDetails;
-        String fileId;
+        String copiedFileId;
 
         System.out.println("testCopyFile...");
 
-        System.out.println("Authenticating...");
-        _wrapper.getClient().getAuthenticationService().authenticateUniversal("java-tester", "java-tester", true, tr);
-        tr.Run();
-
-        System.out.println("Copying file...");
         _wrapper.getGroupFileService().copyFile(
-                groupID,
-                groupFileId,
-                version,
+                _groupId,
+                fileId,
+                -1,
                 "",
                 0,
-                newFileName,
+                copiedFilename,
                 true,
                 tr
         );
         tr.Run();
 
+        // Save data from copied file
         try {
             data = tr.m_response.getJSONObject("data");
             fileDetails = data.getJSONObject("fileDetails");
-            fileId = fileDetails.getString("fileId");
+            copiedFileId = fileDetails.getString("fileId");
 
-            //Delete new file
+            // Delete new file
             System.out.println("Deleting new file...");
             _wrapper.getGroupFileService().deleteFile(
-                    groupID,
-                    fileId,
-                    version,
-                    newFileName,
+                    _groupId,
+                    copiedFileId,
+                    -1,
+                    copiedFilename,
                     tr
             );
             tr.Run();
@@ -359,15 +322,12 @@ public class GroupFileServiceTest extends TestFixtureNoAuth implements IFileUplo
 
     @Test
     public void testUpdateFileInfo(){
+        System.out.println("testUpdateFileInfo");
+        
         TestResult tr = new TestResult(_wrapper);
         JSONObject acl = new JSONObject();
 
-        System.out.println("testUpdateFileInfo...");
-
-        System.out.println("Authenticating...");
-        _wrapper.getClient().getAuthenticationService().authenticateUniversal("java-tester", "java-tester", true, tr);
-        tr.Run();
-
+        // Create acl json object
         try {
             acl.put("other", 0);
             acl.put("member", 2);
@@ -377,22 +337,22 @@ public class GroupFileServiceTest extends TestFixtureNoAuth implements IFileUplo
 
         System.out.println("Updating file info...");
         _wrapper.getGroupFileService().updateFileInfo(
-                groupID,
-                groupFileId,
-                version,
-                updatedName,
+                _groupId,
+                fileId,
+                -1,
+                updatedFilename,
                 acl,
                 tr
         );
         tr.Run();
 
-        //Revert back
+        // Revert back
         System.out.println("Reverting back...");
         _wrapper.getGroupFileService().updateFileInfo(
-                groupID,
-                groupFileId,
-                version,
-                filename,
+                _groupId,
+                fileId,
+                -1,
+                _tempFilename,
                 acl,
                 tr
         );
@@ -400,27 +360,14 @@ public class GroupFileServiceTest extends TestFixtureNoAuth implements IFileUplo
     }
 
     /* Taken from FileServiceTest. */
-    private String createFile(int fileSizeMb) throws Exception {
-        File tempFile = File.createTempFile("test", ".dat");
-        tempFile.deleteOnExit();
-
-        RandomAccessFile raf = new RandomAccessFile(tempFile, "rw");
-
-        int fileSize = fileSizeMb * 1024 * 1024;
-        raf.setLength(fileSize);
-        raf.close();
-
-        return tempFile.getCanonicalPath();
-    }
-
-    private void waitForReturn(String[] uploadIds, Boolean cancelUpload) throws Exception {
+    private static void waitForReturn(String[] uploadIds, Boolean cancelUpload) throws Exception {
         FileService service = _wrapper.getFileService();
         int count = 0;
         Boolean sw = true;
 
         System.out.println("Waiting for file to upload...");
 
-        while (_returnCount < uploadIds.length && count < 1000 * 30) {
+        while (!uploadSuccess && count < 1000 * 30) {
             _wrapper.runCallbacks();
             for (String id : uploadIds) {
                 double progress = service.getUploadProgress(id);
@@ -443,18 +390,8 @@ public class GroupFileServiceTest extends TestFixtureNoAuth implements IFileUplo
         }
     }
 
-    private String getUploadId(JSONObject response) throws Exception {
+    private static String getUploadId(JSONObject response) throws Exception {
         return response.getJSONObject("data").getJSONObject("fileDetails").getString("uploadId");
     }
 
-    @Override
-    public void fileUploadCompleted(String fileUploadId, String jsonResponse) {
-        _returnCount++;
-    }
-
-    @Override
-    public void fileUploadFailed(String fileUploadId, int statusCode, int reasonCode, String jsonResponse) {
-        _returnCount++;
-        _failCount++;
-    }
 }

--- a/src/test/java/com/bitheads/braincloud/services/GroupFileServiceTest.java
+++ b/src/test/java/com/bitheads/braincloud/services/GroupFileServiceTest.java
@@ -1,48 +1,59 @@
 package com.bitheads.braincloud.services;
 
+import com.bitheads.braincloud.client.BrainCloudWrapper;
+import com.bitheads.braincloud.client.IFileUploadCallback;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.junit.Test;
-
-import com.bitheads.braincloud.client.IFileUploadCallback;
+import java.util.HashMap;
 
 public class GroupFileServiceTest extends TestFixtureBase {
 
-    private boolean uploadSuccess;
-    
-    @Test
-    public void oneBigTest() {
+    private static String _tempFilename = "testfile-java.txt";
+    private static String _groupId = "a7ff751c-3251-407a-b2fd-2bd1e9bca64a";
+    private static JSONObject acl = new JSONObject();
+    private static boolean uploadSuccess;
+    private static String fileId = "";
+
+    private String movedFilename = "moved-testfile-java.txt";
+    private String copiedFilename = "copied-testfile-java.txt";
+    private String updatedFilename = "updated-testfile-java.txt";
+
+    /**
+     * Creates and uploads a temporary file to be used for each of the Group File
+     * tests.
+     * Also acts as a test for the moveUserToGroupFile method.
+     * If the file fails to upload or get moved to the group, the other tests should
+     * also fail.
+     */
+    @BeforeClass
+    public static void groupFileSetup() {
+        JSONObject data;
+        JSONObject fileDetails;
+
+        /* From setup() in TestFixtureBase.java */
+        _wrapper = new BrainCloudWrapper();
+        _client = _wrapper.getClient();
         TestResult tr = new TestResult(_wrapper);
-        String tempFilename = "testfile-java.txt";
-        String groupId = "a7ff751c-3251-407a-b2fd-2bd1e9bca64a";
-        String fileId = "";
-        String movedFilename = "moved-testfile-java.txt";
-        String copiedFilename = "copied-testfile-java.txt";
-        String copiedFileId = "";
-        String updatedFilename = "updated-testfile-java.txt";
-        JSONObject acl = new JSONObject();
 
-        // Create acl json object
-        try {
-            acl.put("other", 0);
-            acl.put("member", 2);
-        } catch (JSONException e) {
-            System.out.println("Error creating acl json object");
-            e.printStackTrace();
-        }
+        m_secretMap = new HashMap<String, String>();
+        m_secretMap.put(m_appId, m_secret);
+        m_secretMap.put(m_childAppId, m_childSecret);
 
-        /* Add user to test group */
-        System.out.println("Joining test group...");
-    	_wrapper.getGroupService().joinGroup(groupId, tr);
-    	tr.Run();
-        
-        /* Create and upload a temporary file */
-        _wrapper.getClient().registerFileUploadCallback(new IFileUploadCallback() {
+        _client.initializeWithApps(m_serverUrl, m_appId, m_secretMap, m_appVersion);
+
+        //TODO
+
+        _client.registerFileUploadCallback(new IFileUploadCallback() {
 
             @Override
             public void fileUploadCompleted(String fileUploadId, String jsonResponse) {
@@ -56,9 +67,10 @@ public class GroupFileServiceTest extends TestFixtureBase {
             }
         });
 
+        /* Create and upload a temporary file */
         // Create the file
         System.out.println("Creating file...");
-        File file = new File(tempFilename);
+        File file = new File(_tempFilename);
         try {
             if (file.createNewFile()) {
                 System.out.println("File created.");
@@ -67,18 +79,18 @@ public class GroupFileServiceTest extends TestFixtureBase {
             }
             file.deleteOnExit();
         } catch (IOException e) {
-            System.out.println("Error creating/locating '" + tempFilename + "'");
-            e.printStackTrace();
+            System.out.println("Error creating/locating '" + _tempFilename + "'");
+            throw new RuntimeException(e);
         }
 
         // Upload the file
         System.out.println("Uploading file...");
         _wrapper.getFileService().uploadFile(
                 "TestFolder",
-                tempFilename,
+                _tempFilename,
                 true,
                 true,
-                tempFilename,
+                _tempFilename,
                 tr);
         tr.Run();
 
@@ -94,14 +106,22 @@ public class GroupFileServiceTest extends TestFixtureBase {
         }
         assertTrue(uploadSuccess);
 
-        /* Test: moveUserToGroupFile */
-        System.out.println("Test: moveUserToGroupFile");
+        // Create acl json object
+        try {
+            acl.put("other", 0);
+            acl.put("member", 2);
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+
+        /* moveUserToGroupFile Test */
+        System.out.println("Moving file...");
         _wrapper.getGroupFileService().moveUserToGroupFile(
                 "TestFolder/",
-                tempFilename,
-                groupId,
+                _tempFilename,
+                _groupId,
                 "",
-                tempFilename,
+                _tempFilename,
                 acl,
                 true,
                 tr);
@@ -109,68 +129,124 @@ public class GroupFileServiceTest extends TestFixtureBase {
 
         /* Save group file ID for tests */
         try {
-            JSONObject data = tr.m_response.getJSONObject("data");
-            JSONObject fileDetails = data.getJSONObject("fileDetails");
+            data = tr.m_response.getJSONObject("data");
+            fileDetails = data.getJSONObject("fileDetails");
             fileId = fileDetails.getString("fileId");
         } catch (JSONException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
+    }
 
-        /* Test: checkFilenameExists */
-        System.out.println("Test: checkFilenameExists");
+    @AfterClass
+    public static void groupFileTearDown() {
+        _client.deregisterFileUploadCallback();
+    }
 
-        _wrapper.getGroupFileService().checkFilenameExists(groupId, "", tempFilename, tr);
+    /**
+     * Authenticate a user that has been added to a group.
+     */
+    @Before
+    public void groupFileAuthenticate() {
+        TestResult tr = new TestResult(_wrapper);
+
+        /* Authenticate */
+        _wrapper.getClient().getAuthenticationService().authenticateUniversal(
+                "java-tester",
+                "java-tester",
+                true,
+                tr);
+        tr.Run();
+    }
+
+    @Test
+    public void testCheckFilenameExists() {
+        System.out.println("testCheckFilenameExists");
+
+        TestResult tr = new TestResult(_wrapper);
+        JSONObject data;
+        boolean exists;
+
+        _wrapper.getGroupFileService().checkFilenameExists(_groupId, "", _tempFilename, tr);
         tr.Run();
 
         // Confirm that the file exists
         try {
-            JSONObject data = tr.m_response.getJSONObject("data");
-            boolean exists = data.getBoolean("exists");
-
-            assertTrue(exists);
+            data = tr.m_response.getJSONObject("data");
+            exists = data.getBoolean("exists");
         } catch (JSONException e) {
-            e.printStackTrace();;
+            throw new RuntimeException(e);
         }
+        assertTrue(exists);
+    }
 
-        /* Test: checkFullpathFilenameExists */
-        System.out.println("Test: checkFullpathFilenameExists");
-        _wrapper.getGroupFileService().checkFullpathFilenameExists(groupId, tempFilename, tr);
+    @Test
+    public void testCheckFullpathFilenameExists() {
+        System.out.println("testCheckFullpathFilenameExists");
+
+        TestResult tr = new TestResult(_wrapper);
+        JSONObject data;
+        boolean exists;
+
+        _wrapper.getGroupFileService().checkFullpathFilenameExists(_groupId, _tempFilename, tr);
         tr.Run();
 
         // Confirm that the file exists
         try {
-            JSONObject data = tr.m_response.getJSONObject("data");
-            boolean exists = data.getBoolean("exists");
-
-            assertTrue(exists);
+            data = tr.m_response.getJSONObject("data");
+            exists = data.getBoolean("exists");
         } catch (JSONException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
+        assertTrue(exists);
+    }
 
-        /* Test: getFileInfo */
-        System.out.println("Test: getFileInfo");
-        _wrapper.getGroupFileService().getFileInfo(groupId, fileId, tr);
+    @Test
+    public void testGetFileInfo() {
+        System.out.println("testGetFileInfo");
+
+        TestResult tr = new TestResult(_wrapper);
+
+        _wrapper.getGroupFileService().getFileInfo(_groupId, fileId, tr);
         tr.Run();
+    }
 
-        /* Test: getFileInfoSimple */
-        System.out.println("Test: getFileInfoSimple");
-        _wrapper.getGroupFileService().getFileInfoSimple(groupId, "", tempFilename, tr);
+    @Test
+    public void testGetFileInfoSimple() {
+        System.out.println("testGetFileInfoSimple");
+        
+        TestResult tr = new TestResult(_wrapper);
+
+        _wrapper.getGroupFileService().getFileInfoSimple(_groupId, "", _tempFilename, tr);
         tr.Run();
+    }
 
-        /* Test: getCDNUrl */
-        System.out.println("Test: getCDNUrl");
-        _wrapper.getGroupFileService().getCDNUrl(groupId, fileId, tr);
+    @Test
+    public void testGetCDNUrl() {
+        System.out.println("testGetCDNUrl");
+
+        TestResult tr = new TestResult(_wrapper);
+
+        _wrapper.getGroupFileService().getCDNUrl(_groupId, fileId, tr);
         tr.Run();
+    }
 
-        /* Test: getFileList */
-        System.out.println("Test: getFileList");
-        _wrapper.getGroupFileService().getFileList(groupId, "", true, tr);
+    @Test
+    public void testGetFileList() {
+        System.out.println("testGetFileList");
+
+        TestResult tr = new TestResult(_wrapper);
+        _wrapper.getGroupFileService().getFileList(_groupId, "", true, tr);
         tr.Run();
+    }
 
-        /* Test: moveFile */
-        System.out.println("Test: moveFile");
+    @Test
+    public void testMoveFile(){
+        System.out.println("testMoveFile");
+        
+        TestResult tr = new TestResult(_wrapper);
+
         _wrapper.getGroupFileService().moveFile(
-                groupId,
+                _groupId,
                 fileId,
                 -1,
                 "",
@@ -184,21 +260,29 @@ public class GroupFileServiceTest extends TestFixtureBase {
         // Revert back
         System.out.println("Moving back...");
         _wrapper.getGroupFileService().moveFile(
-                groupId,
+                _groupId,
                 fileId,
                 -1,
                 "",
                 0,
-                tempFilename,
+                _tempFilename,
                 true,
                 tr
         );
         tr.Run();
+    }
 
-        /* Test: copyFile */
-        System.out.println("Test: copyFile");
+    @Test
+    public void testCopyFile(){
+        TestResult tr = new TestResult(_wrapper);
+        JSONObject data;
+        JSONObject fileDetails;
+        String copiedFileId;
+
+        System.out.println("testCopyFile...");
+
         _wrapper.getGroupFileService().copyFile(
-                groupId,
+                _groupId,
                 fileId,
                 -1,
                 "",
@@ -211,29 +295,43 @@ public class GroupFileServiceTest extends TestFixtureBase {
 
         // Save data from copied file
         try {
-            JSONObject data = tr.m_response.getJSONObject("data");
-            JSONObject fileDetails = data.getJSONObject("fileDetails");
+            data = tr.m_response.getJSONObject("data");
+            fileDetails = data.getJSONObject("fileDetails");
             copiedFileId = fileDetails.getString("fileId");
+
+            // Delete new file
+            System.out.println("Deleting new file...");
+            _wrapper.getGroupFileService().deleteFile(
+                    _groupId,
+                    copiedFileId,
+                    -1,
+                    copiedFilename,
+                    tr
+            );
+            tr.Run();
         } catch (JSONException e) {
             e.printStackTrace();
         }
+    }
 
-        /* Test: deleteFile */
-        // Delete file from copyFile test
-        System.out.println("Test: deleteFile");
-        _wrapper.getGroupFileService().deleteFile(
-                groupId,
-                copiedFileId,
-                -1,
-                copiedFilename,
-                tr
-        );
-        tr.Run();
+    @Test
+    public void testUpdateFileInfo(){
+        System.out.println("testUpdateFileInfo");
+        
+        TestResult tr = new TestResult(_wrapper);
+        JSONObject acl = new JSONObject();
 
-        /* Test: updateFileInfo */
-        System.out.println("Test: updateFileInfo");
+        // Create acl json object
+        try {
+            acl.put("other", 0);
+            acl.put("member", 2);
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+
+        System.out.println("Updating file info...");
         _wrapper.getGroupFileService().updateFileInfo(
-                groupId,
+                _groupId,
                 fileId,
                 -1,
                 updatedFilename,
@@ -245,20 +343,18 @@ public class GroupFileServiceTest extends TestFixtureBase {
         // Revert back
         System.out.println("Reverting back...");
         _wrapper.getGroupFileService().updateFileInfo(
-                groupId,
+                _groupId,
                 fileId,
                 -1,
-                tempFilename,
+                _tempFilename,
                 acl,
                 tr
         );
         tr.Run();
-
-        _wrapper.getClient().deregisterFileUploadCallback();
     }
 
     /* Taken from FileServiceTest. */
-    private void waitForReturn(String[] uploadIds, Boolean cancelUpload) throws Exception {
+    private static void waitForReturn(String[] uploadIds, Boolean cancelUpload) throws Exception {
         FileService service = _wrapper.getFileService();
         int count = 0;
         Boolean sw = true;
@@ -288,7 +384,8 @@ public class GroupFileServiceTest extends TestFixtureBase {
         }
     }
 
-    private String getUploadId(JSONObject response) throws Exception {
+    private static String getUploadId(JSONObject response) throws Exception {
         return response.getJSONObject("data").getJSONObject("fileDetails").getString("uploadId");
     }
+
 }

--- a/src/test/java/com/bitheads/braincloud/services/TestFixtureBase.java
+++ b/src/test/java/com/bitheads/braincloud/services/TestFixtureBase.java
@@ -46,8 +46,6 @@ public class TestFixtureBase {
     @Before
     public void setUp() throws Exception {
 
-        //LoadIds();
-
         _wrapper = new BrainCloudWrapper();
         _client = _wrapper.getClient();
 

--- a/src/test/java/com/bitheads/braincloud/services/TestFixtureBase.java
+++ b/src/test/java/com/bitheads/braincloud/services/TestFixtureBase.java
@@ -12,6 +12,7 @@ import java.util.Random;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 
 import com.bitheads.braincloud.client.AuthenticationType;
 import com.bitheads.braincloud.client.BrainCloudClient;
@@ -37,10 +38,15 @@ public class TestFixtureBase {
         return m_serverUrl;
     }
 
+    @BeforeClass
+    public static void getIds(){
+        LoadIds();
+    }
+
     @Before
     public void setUp() throws Exception {
 
-        LoadIds();
+        //LoadIds();
 
         _wrapper = new BrainCloudWrapper();
         _client = _wrapper.getClient();
@@ -85,7 +91,7 @@ public class TestFixtureBase {
     /// Routine loads up brainCloud configuration info from "tests/ids.txt" (hopefully)
     /// in a platform agnostic way.
     /// </summary>
-    private void LoadIds() {
+    private static void LoadIds() {
         if (m_serverUrl.length() > 0) return;
 
         File idsFile = new File("ids.txt");


### PR DESCRIPTION
- Restructured the GroupFile test class
- User joins the group prior to tests 
- A test file is uploaded prior to the tests
    - Removes risk of test failing if the test file is mistakenly deleted or if the user is deleted/removed from the group
- Added update contact email and removed hard coded universal id for resetUniversalId tests