### PR TITLE
BCLOUD-9471

### DIFF
--- a/src/main/java/com/bitheads/braincloud/services/PushNotificationService.java
+++ b/src/main/java/com/bitheads/braincloud/services/PushNotificationService.java
@@ -88,9 +88,9 @@ public class PushNotificationService {
             if (callback != null) {
                 String errorJson = String.format(
                     "{\"status\":%d,\"reason_code\":%d,\"message\":\"Invalid device token: %s\"}",
-                    STATUS_CODE, INVALID_DEVICE_TOKEN, token
+                    STATUS_CODE, ReasonCodes.INVALID_DEVICE_TOKEN, token
                 );
-                callback.serverError(STATUS_CODE, INVALID_DEVICE_TOKEN, errorJson);
+                callback.serverError(ServiceName.pushNotification, ServiceOperation.REGISTER, STATUS_CODE, ReasonCodes.INVALID_DEVICE_TOKEN, errorJson);
             }
             return;
         }

--- a/src/main/java/com/bitheads/braincloud/services/PushNotificationService.java
+++ b/src/main/java/com/bitheads/braincloud/services/PushNotificationService.java
@@ -3,6 +3,7 @@ package com.bitheads.braincloud.services;
 import com.bitheads.braincloud.client.BrainCloudClient;
 import com.bitheads.braincloud.client.IServerCallback;
 import com.bitheads.braincloud.client.Platform;
+import com.bitheads.braincloud.client.ReasonCodes;
 import com.bitheads.braincloud.client.ServiceName;
 import com.bitheads.braincloud.client.ServiceOperation;
 import com.bitheads.braincloud.comms.ServerCall;
@@ -81,6 +82,19 @@ public class PushNotificationService {
      * @param callback The method to be invoked when the server response is received
      */
     public void registerPushNotificationToken(Platform platform, String token, IServerCallback callback) {
+        final int STATUS_CODE = 400;
+
+        if (token == null || token.trim().isEmpty()) {
+            if (callback != null) {
+                String errorJson = String.format(
+                    "{\"status\":%d,\"reason_code\":%d,\"message\":\"Invalid device token: %s\"}",
+                    STATUS_CODE, INVALID_DEVICE_TOKEN, token
+                );
+                callback.serverError(STATUS_CODE, INVALID_DEVICE_TOKEN, errorJson);
+            }
+            return;
+        }
+
         try {
             JSONObject data = new JSONObject();
             data.put(Parameter.deviceType.name(), platform.toString());

--- a/src/main/java/com/bitheads/braincloud/services/PushNotificationService.java
+++ b/src/main/java/com/bitheads/braincloud/services/PushNotificationService.java
@@ -90,6 +90,10 @@ public class PushNotificationService {
                     "{\"status\":%d,\"reason_code\":%d,\"message\":\"Invalid device token: %s\"}",
                     STATUS_CODE, ReasonCodes.INVALID_DEVICE_TOKEN, token
                 );
+
+                if(_client.getRestClient().getLoggingEnabled()){
+                    System.out.println("Push notification token not registered - empty/null tokens are invalid");
+                }
                 callback.serverError(ServiceName.pushNotification, ServiceOperation.REGISTER, STATUS_CODE, ReasonCodes.INVALID_DEVICE_TOKEN, errorJson);
             }
             return;

--- a/src/test/java/com/bitheads/braincloud/services/PushNotificationServiceTest.java
+++ b/src/test/java/com/bitheads/braincloud/services/PushNotificationServiceTest.java
@@ -45,6 +45,18 @@ public class PushNotificationServiceTest extends TestFixtureBase
         tr.Run();
     }
 
+    // TODO:  Test receives expected failure right away, but continues waiting for server response. Must improve TestResult setup to allow this.
+    // @Test
+    // public void testRegisterEmptyPushNotificationToken() throws Exception
+    // {
+    // TestResult tr = new TestResult(_wrapper);
+
+    // _wrapper.getPushNotificationService().registerPushNotificationToken(
+    // Platform.GooglePlayAndroid, "", tr);
+
+    // tr.RunExpectFail(400, ReasonCodes.INVALID_DEVICE_TOKEN);
+    // }
+
     @Test
     public void testSendSimplePushNotification() throws Exception
     {


### PR DESCRIPTION
Client Library update - Update the client libs to Catch the case when the app requests notifications and the user denies it, resulting in an "empty token" being saved into the place that stores the notification token - Java