### PR TITLE
Features/long session rtt relay protection

### DIFF
--- a/src/main/java/com/bitheads/braincloud/client/BrainCloudWrapper.java
+++ b/src/main/java/com/bitheads/braincloud/client/BrainCloudWrapper.java
@@ -732,6 +732,13 @@ public class BrainCloudWrapper implements IServerCallback, IBrainCloudWrapper {
         getClient().getAuthenticationService().authenticateAnonymous(false, this);
     }
 
+    @Override
+    public void enableLongSession(boolean longSessionEnabled){
+        initializeIdentity(true);
+        
+        getClient().getRestClient().setLongSessionEnabled(longSessionEnabled);
+    }
+
         /**
      * Authenticate the user with a custom Email and Password. Note that the
      * client app is responsible for collecting (and storing) the e-mail and

--- a/src/main/java/com/bitheads/braincloud/client/IBrainCloudWrapper.java
+++ b/src/main/java/com/bitheads/braincloud/client/IBrainCloudWrapper.java
@@ -349,6 +349,12 @@ public interface IBrainCloudWrapper {
 	void reconnect(IServerCallback callback);
 
 	/**
+	 * When enabled, automatically attempt to reconnect and retry server calls in the event of an expired session.
+	 * @param enableLongSession Determines if Long Session should be enabled or not
+	 */
+	void enableLongSession(boolean enableLongSession);
+
+	/**
 	 * Authenticate the user with a custom Email and Password. Note that the
 	 * client app is responsible for collecting (and storing) the e-mail and
 	 * potentially password (for convenience) in the client data. For the

--- a/src/main/java/com/bitheads/braincloud/comms/BrainCloudRestClient.java
+++ b/src/main/java/com/bitheads/braincloud/comms/BrainCloudRestClient.java
@@ -7,6 +7,7 @@ import com.bitheads.braincloud.client.IFileUploadCallback;
 import com.bitheads.braincloud.client.IGlobalErrorCallback;
 import com.bitheads.braincloud.client.INetworkErrorCallback;
 import com.bitheads.braincloud.client.IRewardCallback;
+import com.bitheads.braincloud.client.IServerCallback;
 import com.bitheads.braincloud.client.ReasonCodes;
 import com.bitheads.braincloud.client.ServiceName;
 import com.bitheads.braincloud.client.ServiceOperation;
@@ -30,7 +31,9 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -68,6 +71,7 @@ public class BrainCloudRestClient implements Runnable {
     private long _lastReceivedPacket;
     private boolean _compressRequests = true;
     private int _compressionThreshold = 51200;
+    private boolean _longSessionEnabled = false;
 
     private int _uploadLowTransferTimeoutSecs = 120;
     private int _uploadLowTransferThresholdSecs = 50;
@@ -141,6 +145,10 @@ public class BrainCloudRestClient implements Runnable {
 
     public void setCompressRequests(boolean compressRequests){
         _compressRequests = compressRequests;
+    }
+
+    public void setLongSessionEnabled(boolean longSessionEnabled){
+        _longSessionEnabled = longSessionEnabled;
     }
 
     public void initialize(String serverUrl, String appId, String secretKey) {
@@ -1124,6 +1132,67 @@ public class BrainCloudRestClient implements Runnable {
                         }
                         String statusMessage = message.getString("status_message");
 
+                        // If the authenticated session has expired, and long session is enabled, attempt to re-authenticate and retry lost call(s)
+                        if (reasonCode == ReasonCodes.USER_SESSION_EXPIRED && _longSessionEnabled
+                                && sc.getServiceOperation() != ServiceOperation.AUTHENTICATE && isAuthenticated()) {
+
+                            // save the call that failed
+                            ServerCall expiredServerCall = sc;
+
+                            // save calls in queue
+                            List<ServerCall> queuedServerCalls = new ArrayList<>();
+                            _waitingQueue.drainTo(queuedServerCalls);
+
+                            if (_loggingEnabled) {
+                                System.out
+                                        .println("Session expired. Long Session enabled - Attempting reconnect . . .");
+                            }
+
+                            _packetId = 0;
+
+                            // Attempt to reconnect user
+                            _client.getAuthenticationService().authenticateAnonymous(false, new IServerCallback() {
+
+                                @Override
+                                public void serverCallback(ServiceName serviceName, ServiceOperation serviceOperation,
+                                        JSONObject jsonData) {
+                                    if (_loggingEnabled) {
+                                        System.out.println("Long Session reconnect successful");
+                                    }
+
+                                    // if any calls were in progress or failed, re-queue them
+                                    if (expiredServerCall != null) {
+                                        
+                                        // re-queue the call that failed first...
+                                        _waitingQueue.add(expiredServerCall);
+
+                                        // ... then re-queue any other calls that were in queue
+                                        _waitingQueue.addAll(queuedServerCalls);
+                                    }
+
+                                    return;
+                                }
+
+                                @Override
+                                public void serverError(ServiceName serviceName, ServiceOperation serviceOperation,
+                                        int statusCode, int reasonCode, String jsonError) {
+                                    if (_loggingEnabled) {
+                                        System.out.println("Long Session reconnect failed");
+                                    }
+
+                                    setLongSessionEnabled(false);
+
+                                    if (expiredServerCall != null && expiredServerCall.getCallback() != null) {
+                                        expiredServerCall.getCallback().serverError(serviceName, serviceOperation,
+                                                statusCode, reasonCode, jsonError);
+                                    }
+                                }
+
+                            });
+
+                            return;
+                        }
+                        
                         if (reasonCode == ReasonCodes.USER_SESSION_EXPIRED
                                 || reasonCode == ReasonCodes.NO_SESSION
                                 || reasonCode == ReasonCodes.USER_SESSION_LOGGED_OUT) {

--- a/src/main/java/com/bitheads/braincloud/comms/BrainCloudRestClient.java
+++ b/src/main/java/com/bitheads/braincloud/comms/BrainCloudRestClient.java
@@ -125,6 +125,14 @@ public class BrainCloudRestClient implements Runnable {
         }
     }
 
+    public boolean getKillSwitchEngaged(){
+        return _killSwitchEngaged;
+    }
+
+    public void setKillSwitchEngaged(boolean killSwitchEngaged){
+        _killSwitchEngaged = killSwitchEngaged;
+    }
+
     public BrainCloudRestClient(BrainCloudClient client) {
         _client = client;
         setPacketTimeoutsToDefault();

--- a/src/main/java/com/bitheads/braincloud/comms/RTTComms.java
+++ b/src/main/java/com/bitheads/braincloud/comms/RTTComms.java
@@ -208,6 +208,16 @@ public class RTTComms implements IServerCallback {
             }
             case Disconnected:
             {
+                if (!_client.isAuthenticated() || _client.getRestClient().getKillSwitchEngaged()) {
+                    callback.rttConnectFailure("Invalid Session - Must be authenticated before enabling RTT.");
+
+                    if (_loggingEnabled) {
+                        System.out.println("The user is not currently authenticated - cannot enable RTT.");
+                    }
+
+                    break;
+                }
+
                 _rttConnectionStatus = RTTComms.RttConnectionStatus.RequestingConnectionInfo;
                 _connectCallback = callback;
                 _useWebSocket = useWebSocket;

--- a/src/main/java/com/bitheads/braincloud/comms/RelayComms.java
+++ b/src/main/java/com/bitheads/braincloud/comms/RelayComms.java
@@ -280,6 +280,16 @@ public class RelayComms {
      * @param callback The method to be invoked when the server response is received
      */
     public void connect(RelayConnectionType connectionType, JSONObject options, IRelayConnectCallback callback) {
+        if (!_client.isAuthenticated()) {
+            callback.relayConnectFailure("Invalid Session - Must be authenticated before connecting to Relay Server.");
+
+            if (_loggingEnabled) {
+                System.out.println("The user is not currently authenticated - cannot connect to Relay Server.");
+            }
+
+            return;
+        }
+        
         if (_isConnected) {
             disconnect();
         }

--- a/src/test/java/com/bitheads/braincloud/services/BrainCloudWrapperTest.java
+++ b/src/test/java/com/bitheads/braincloud/services/BrainCloudWrapperTest.java
@@ -233,7 +233,7 @@ public class BrainCloudWrapperTest extends TestFixtureNoAuth {
         userWrapper.getScriptService().runScript("LogoutSession", jsonScriptData, userTr);
         userTr.Run();
 
-        // Verify session retries via long session
+        // Verify session retries via long session (if long session isn't enabled, this should fail)
         _wrapper.getIdentityService().getIdentities(tr);
         tr.Run();
     }

--- a/src/test/java/com/bitheads/braincloud/services/BrainCloudWrapperTest.java
+++ b/src/test/java/com/bitheads/braincloud/services/BrainCloudWrapperTest.java
@@ -1,13 +1,18 @@
 package com.bitheads.braincloud.services;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
+import java.util.HashMap;
+
+import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.bitheads.braincloud.client.BrainCloudWrapper;
 import com.bitheads.braincloud.client.ReasonCodes;
 import com.bitheads.braincloud.client.ServiceName;
 import com.bitheads.braincloud.client.ServiceOperation;
@@ -179,5 +184,57 @@ public class BrainCloudWrapperTest extends TestFixtureNoAuth {
         System.out.println("Status Code CLIENT_NETWORK_ERROR = " + statusCode);
 
         Assert.assertEquals(expectedValue, statusCode);
+    }
+
+    @Test
+    public void LongSessionEnabled(){
+        BrainCloudWrapper userWrapper = new BrainCloudWrapper();
+        m_secretMap = new HashMap<String, String>();
+        m_secretMap.put(m_appId, m_secret);
+        m_secretMap.put(m_childAppId, m_childSecret);
+        userWrapper.getClient().initializeWithApps(m_serverUrl, m_appId, m_secretMap, m_appVersion);
+        userWrapper.getClient().enableLogging(true);
+
+        TestResult userTr = new TestResult(userWrapper);
+
+        userWrapper.authenticateUniversal("primaryUser", "primaryUser", true, userTr);
+        userTr.Run();
+
+        _wrapper.getClient().enableLogging(true);
+        _wrapper.enableLongSession(true);
+
+        TestResult tr = new TestResult(_wrapper);
+        _wrapper.authenticateUniversal("secondaryUser", "secondaryUser", true, tr);
+        tr.Run();
+
+
+        // Save Profile and Session IDs so that the session can be ended with a Cloud Code Script
+        JSONObject responseData = tr.m_response.optJSONObject("data");
+        if(responseData == null){
+            fail("Failed to get response data");
+        }
+        
+        String profileId = responseData.optString("profileId");
+        String sessionId = responseData.optString("sessionId");
+
+        assertFalse( "profileId empty", profileId.isEmpty());
+        assertFalse("sessionId empty", sessionId.isEmpty());
+
+        JSONObject profileSessionObj = new JSONObject();
+        profileSessionObj.put("profileId", profileId);
+        profileSessionObj.put("sessionId", sessionId);
+        String jsonScriptData = profileSessionObj.toString();
+
+        // Verify session is active
+        _wrapper.getIdentityService().getIdentities(tr);
+        tr.Run();
+
+        // End session via script
+        userWrapper.getScriptService().runScript("LogoutSession", jsonScriptData, userTr);
+        userTr.Run();
+
+        // Verify session retries via long session
+        _wrapper.getIdentityService().getIdentities(tr);
+        tr.Run();
     }
 }

--- a/src/test/java/com/bitheads/braincloud/services/RTTTest.java
+++ b/src/test/java/com/bitheads/braincloud/services/RTTTest.java
@@ -13,6 +13,21 @@ import com.bitheads.braincloud.client.IRTTConnectCallback;
 public class RTTTest extends TestFixtureBase
 {
     @Test
+    public void testEnableRTTNoAuth() throws Exception {
+        TestResult tr = new TestResult(_wrapper);
+
+        if(_wrapper.getClient().isAuthenticated()){
+            _wrapper.logout(false, tr);
+            tr.Run();
+        }
+
+        RTTConnectionTestResult rttTr = new RTTConnectionTestResult(_wrapper);
+
+        _wrapper.getRTTService().enableRTT(rttTr);
+        rttTr.RunExpectFail();
+    }
+    
+    @Test
     public void testRequestClientConnection() throws Exception {
         TestResult tr = new TestResult(_wrapper);
 
@@ -89,6 +104,7 @@ public class RTTTest extends TestFixtureBase
     public class RTTConnectionTestResult implements IRTTConnectCallback {
         private boolean m_result = false;
         private boolean m_done = false;
+        private boolean m_failureCallbackReceived = false;
         
         IBrainCloudWrapper _wrapper;
 
@@ -103,14 +119,23 @@ public class RTTTest extends TestFixtureBase
             return m_result;
         }
 
+        public boolean RunExpectFail(){
+            Spin();
+            Assert.assertTrue(m_failureCallbackReceived);
+            return m_result;
+        }
+
         public void rttConnectSuccess() {
             m_result = true;
             m_done = true;
         }
 
         public void rttConnectFailure(String errorMessage) {
+            System.out.println("RTT Connect Failure: " + errorMessage);
+            
             m_result = false;
             m_done = true;
+            m_failureCallbackReceived = true;
         }
 
         public boolean IsDone()

--- a/src/test/java/com/bitheads/braincloud/services/RelayTest.java
+++ b/src/test/java/com/bitheads/braincloud/services/RelayTest.java
@@ -166,6 +166,64 @@ public class RelayTest extends TestFixtureBase {
     }
 
     @Test
+    public void testFullFlowNoAuth() throws Exception {
+        RTTLobbyResults lobbyTR = new RTTLobbyResults(_wrapper);
+        JSONObject server;
+
+        _wrapper.getClient().getRTTService().registerRTTLobbyCallback(lobbyTR);
+
+        // Enable RTT
+        {
+            System.out.println("Enable RTT...");
+            RTTConnectionTestResult tr = new RTTConnectionTestResult(_wrapper);
+            _wrapper.getClient().getRTTService().enableRTT(tr, true);
+            tr.Run();
+        }
+
+        // Find or create lobby
+        {
+            System.out.println("Find or create lobby...");
+            TestResult tr = new TestResult(_wrapper);
+            _wrapper.getLobbyService().findOrCreateLobby("READY_START_V2", 0, 1,
+                    "{\"strategy\":\"ranged-absolute\",\"alignment\":\"center\",\"ranges\":[1000]}", "{}", null, "{}",
+                    true, "{}", "all", tr);
+            tr.Run();
+            server = lobbyTR.Run();
+        }
+
+        // Register callbacks
+        System.out.println("Register callbacks...");
+        RelayConnectSystemCheck systemCallbackReceived = new RelayConnectSystemCheck(_wrapper);
+        _wrapper.getRelayService().registerSystemCallback(systemCallbackReceived);
+        RelayCheck relayCallbackReceived = new RelayCheck(_wrapper);
+        _wrapper.getRelayService().registerRelayCallback(relayCallbackReceived);
+
+        // Logout to verify connect will not be attempted when not authenticated
+        TestResult tr1 = new TestResult(_wrapper);
+
+        if (_wrapper.getClient().isAuthenticated()) {
+            _wrapper.logout(false, tr1);
+            tr1.Run();
+        }
+
+        // Connect to relay server
+        {
+            System.out.println("Connect to relay server...");
+            RelayConnectionTestResult tr = new RelayConnectionTestResult(_wrapper);
+            JSONObject options = new JSONObject();
+            options.put("ssl", false);
+            options.put("host", server.getJSONObject("connectData").getString("address"));
+
+            options.put("port", server.getJSONObject("connectData").getJSONObject("ports").getInt("ws"));
+
+            options.put("passcode", server.getString("passcode"));
+            options.put("lobbyId", server.getString("lobbyId"));
+            _wrapper.getRelayService().connect(RelayConnectionType.WEBSOCKET, options, tr);
+            tr.RunExpectFail();
+        }
+    }
+    
+    @Test
     public void testFullFlowWS() throws Exception {
         fullFlow(RelayConnectionType.WEBSOCKET);
     }

--- a/src/test/java/com/bitheads/braincloud/services/RelayTest.java
+++ b/src/test/java/com/bitheads/braincloud/services/RelayTest.java
@@ -228,11 +228,10 @@ public class RelayTest extends TestFixtureBase {
         fullFlow(RelayConnectionType.WEBSOCKET);
     }
 
-    // Disabled as of 29/01/2026
-    // @Test
-    // public void testFullFlowTCP() throws Exception {
-    //     fullFlow(RelayConnectionType.TCP);
-    // }
+    @Test
+    public void testFullFlowTCP() throws Exception {
+        fullFlow(RelayConnectionType.TCP);
+    }
 
     @Test
     public void testFullFlowUDP() throws Exception {

--- a/src/test/java/com/bitheads/braincloud/services/RelayTest.java
+++ b/src/test/java/com/bitheads/braincloud/services/RelayTest.java
@@ -228,10 +228,11 @@ public class RelayTest extends TestFixtureBase {
         fullFlow(RelayConnectionType.WEBSOCKET);
     }
 
-    @Test
-    public void testFullFlowTCP() throws Exception {
-        fullFlow(RelayConnectionType.TCP);
-    }
+    // Disabled as of 29/01/2026
+    // @Test
+    // public void testFullFlowTCP() throws Exception {
+    //     fullFlow(RelayConnectionType.TCP);
+    // }
 
     @Test
     public void testFullFlowUDP() throws Exception {


### PR DESCRIPTION
- BCLOUD-12200
   - EnableRTT and Relay.Connect now check if the user is authenticated (session is active/valid) before attempting to enable/connect and return a failure callback if not
- BCLOUD-10089
   - EnableLongSession allows for automatic re-authentication and request retry if a session expires

Green Test: https://vmjenkins.bitheads.com/view/Dev_Java/job/bitHeads_BrainCloud_Client_UnitTest_Java_develop_internal/1039/console